### PR TITLE
feat: addFileSource() — upload local files via Scotty protocol

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,15 +46,17 @@ function addSourceOptions(cmd: Command): Command {
   return cmd
     .option('--url <url>', 'Source URL')
     .option('--text <text>', 'Source text content')
+    .option('--file <path>', 'Local file path (pdf, txt, md, docx, csv, pptx, epub, mp3, wav, etc.)')
     .option('--topic <topic>', 'Research topic')
     .option('--research-mode <mode>', 'Research mode: fast or deep', 'fast');
 }
 
-function buildSource(opts: { url?: string; text?: string; topic?: string; researchMode?: string }): SourceInput {
+function buildSource(opts: { url?: string; text?: string; file?: string; topic?: string; researchMode?: string }): SourceInput {
   if (opts.url) return { type: 'url', url: opts.url };
   if (opts.text) return { type: 'text', text: opts.text };
+  if (opts.file) return { type: 'file', filePath: opts.file };
   if (opts.topic) return { type: 'research', topic: opts.topic, researchMode: (opts.researchMode as 'fast' | 'deep') ?? 'fast' };
-  throw new Error('Must specify --url, --text, or --topic');
+  throw new Error('Must specify --url, --text, --file, or --topic');
 }
 
 async function withClient(

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,8 +9,8 @@
  *   - 'auto':             Best available non-browser transport
  */
 
-import { mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, statSync, readFileSync } from 'node:fs';
+import { join, resolve, basename } from 'node:path';
 import { type Page } from 'puppeteer-core';
 import { SessionError, UserDisplayableError } from './errors.js';
 import { humanSleep, jitteredIncrement } from './utils/humanize.js';
@@ -395,6 +395,134 @@ export class NotebookClient {
       `/notebook/${notebookId}`,
     );
     return parseAddSource(raw);
+  }
+
+  /**
+   * Upload a local file as a source. Works with all transports.
+   *
+   * Uses Google's Scotty resumable upload protocol:
+   *   1. Register file source via RPC (ADD_SOURCE_FILE)
+   *   2. Initiate resumable upload session
+   *   3. Upload raw file bytes
+   *
+   * Supported: pdf, txt, md, docx, csv, pptx, epub, mp3, wav, m4a, png, jpg, gif, etc.
+   */
+  async addFileSource(notebookId: string, filePath: string): Promise<{ sourceId: string; title: string }> {
+    if (!this.transport) throw new SessionError('Not connected');
+
+    const absPath = resolve(filePath);
+    const stat = statSync(absPath);
+    if (!stat.isFile()) throw new Error(`Not a file: ${absPath}`);
+    const fileName = basename(absPath);
+    const fileSize = stat.size;
+
+    // Step 1: Register file source via RPC
+    const raw = await this.callBatchExecute(
+      NB_RPC.ADD_SOURCE_FILE,
+      [
+        [[fileName]],
+        notebookId,
+        [...PLATFORM_WEB],
+        [1, null, null, null, null, null, null, null, null, null, [1]],
+      ],
+      `/notebook/${notebookId}`,
+    );
+    const { sourceId } = parseAddSource(raw);
+    if (!sourceId) throw new Error('Failed to register file source — no sourceId returned');
+
+    // Steps 2+3: Upload file via Scotty resumable protocol
+    const fileBuffer = readFileSync(absPath);
+    await this.scottyUpload(notebookId, fileName, sourceId, fileSize, fileBuffer);
+
+    return { sourceId, title: fileName };
+  }
+
+  /**
+   * Execute Scotty resumable upload: initiate session → upload bytes.
+   * Uses a single HTTP agent for both requests.
+   */
+  private async scottyUpload(
+    notebookId: string, fileName: string, sourceId: string, fileSize: number, fileBuffer: Buffer,
+  ): Promise<void> {
+    const { request: undiciRequest, Agent, ProxyAgent } = await import('undici');
+    const { CHROME_CIPHERS } = await import('./tls-config.js');
+    const session = this.transport!.getSession();
+
+    const baseHeaders: Record<string, string> = {
+      'Accept': '*/*',
+      'Cookie': session.cookies,
+      'Origin': 'https://notebooklm.google.com',
+      'Referer': 'https://notebooklm.google.com/',
+      'User-Agent': session.userAgent,
+      'x-goog-authuser': '0',
+    };
+
+    let dispatcher: InstanceType<typeof Agent> | InstanceType<typeof ProxyAgent>;
+    if (this.proxy) {
+      dispatcher = new ProxyAgent({
+        uri: this.proxy,
+        requestTls: { ciphers: CHROME_CIPHERS, minVersion: 'TLSv1.2', maxVersion: 'TLSv1.3' },
+      });
+    } else {
+      dispatcher = new Agent({
+        connect: {
+          ciphers: CHROME_CIPHERS,
+          minVersion: 'TLSv1.2',
+          maxVersion: 'TLSv1.3',
+          ALPNProtocols: ['h2', 'http/1.1'],
+        } as Record<string, unknown>,
+      });
+    }
+
+    const doPost = async (
+      url: string, headers: Record<string, string>, body: string | Buffer,
+    ): Promise<{ status: number; headers: Record<string, string>; body: string }> => {
+      const response = await undiciRequest(url, {
+        method: 'POST', headers, body, dispatcher,
+        headersTimeout: 300_000,
+        bodyTimeout: 300_000,
+      });
+      const responseBody = await response.body.text();
+      const responseHeaders: Record<string, string> = {};
+      for (const [key, value] of Object.entries(response.headers)) {
+        if (typeof value === 'string') {
+          responseHeaders[key] = value;
+        } else if (Array.isArray(value) && value[0] != null) {
+          responseHeaders[key] = value[0];
+        }
+      }
+      return { status: response.statusCode, headers: responseHeaders, body: responseBody };
+    };
+
+    try {
+      // Step 2: Initiate resumable upload session
+      const initResp = await doPost(`${NB_URLS.UPLOAD}?authuser=0`, {
+        ...baseHeaders,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'x-goog-upload-command': 'start',
+        'x-goog-upload-header-content-length': String(fileSize),
+        'x-goog-upload-protocol': 'resumable',
+      }, JSON.stringify({ PROJECT_ID: notebookId, SOURCE_NAME: fileName, SOURCE_ID: sourceId }));
+
+      const uploadUrl = initResp.headers['x-goog-upload-url'];
+      if (!uploadUrl) {
+        throw new Error(`Upload session initiation failed (HTTP ${initResp.status}): no x-goog-upload-url in response`);
+      }
+
+      // Step 3: Upload file bytes
+      const uploadResp = await doPost(uploadUrl, {
+        ...baseHeaders,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+        'x-goog-upload-command': 'upload, finalize',
+        'x-goog-upload-offset': '0',
+      }, fileBuffer);
+
+      if (uploadResp.status < 200 || uploadResp.status >= 300) {
+        throw new Error(`File upload failed (HTTP ${uploadResp.status}): ${uploadResp.body.slice(0, 200)}`);
+      }
+    } finally {
+      await dispatcher.close();
+    }
   }
 
   async createWebSearch(notebookId: string, query: string, mode: 'fast' | 'deep' = 'fast'): Promise<{ researchId: string; artifactId?: string }> {
@@ -1042,6 +1170,10 @@ export class NotebookClient {
       }
       case 'text': {
         const { sourceId } = await this.addTextSource(notebookId, 'Pasted Text', source.text!);
+        return [sourceId];
+      }
+      case 'file': {
+        const { sourceId } = await this.addFileSource(notebookId, source.filePath!);
         return [sourceId];
       }
       case 'research': {

--- a/src/rpc-ids.ts
+++ b/src/rpc-ids.ts
@@ -13,6 +13,7 @@ export const NB_RPC = {
 
   // ── Sources ──
   ADD_SOURCE: 'izAoDd',
+  ADD_SOURCE_FILE: 'o4cbdc',
   GET_SOURCE_CONTENT: 'hizoJc',
   GET_SOURCE_SUMMARY: 'tr032e',
   DELETE_SOURCE: 'tGMBJ',
@@ -73,6 +74,7 @@ export const NB_URLS = {
   DASHBOARD: 'https://notebooklm.google.com/',
   BATCH_EXECUTE: 'https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute',
   CHAT_STREAM: 'https://notebooklm.google.com/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed',
+  UPLOAD: 'https://notebooklm.google.com/upload/_/',
 } as const;
 
 export const DEFAULT_USER_CONFIG = [2, null, null, [1, null, null, null, null, null, null, null, null, null, [1]], [[2, 1, 3]]] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@
 
 // ── Enums ──
 
-export type SourceType = 'url' | 'text' | 'research';
+export type SourceType = 'url' | 'text' | 'research' | 'file';
 export type ResearchMode = 'fast' | 'deep';
 export type AudioLanguage = 'en' | 'zh' | 'ja' | 'ko' | 'es' | 'fr' | 'de' | 'pt' | 'it' | 'hi';
 export type AudioFormat = 'conversation' | 'lecture' | 'briefing';
@@ -36,6 +36,7 @@ export interface SourceInput {
   url?: string;
   text?: string;
   topic?: string;
+  filePath?: string;
   researchMode?: ResearchMode;
 }
 

--- a/tests/e2e-file-upload.test.ts
+++ b/tests/e2e-file-upload.test.ts
@@ -1,0 +1,96 @@
+/**
+ * E2E tests for addFileSource (local file upload via Scotty protocol).
+ *
+ * Requires a valid session (run `npx notebooklm export-session` first).
+ * Uses the work account for quota headroom:
+ *   NOTEBOOKLM_HOME=~/.notebooklm-work npx vitest run tests/e2e-file-upload.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { NotebookClient } from '../src/client.js';
+import { loadSession } from '../src/session-store.js';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+let client: NotebookClient;
+let hasSession = false;
+let testNotebookId = '';
+const tmpFiles: string[] = [];
+
+function createTmpFile(name: string, content: string): string {
+  const p = join(tmpdir(), `notebooklm-e2e-${Date.now()}-${name}`);
+  writeFileSync(p, content, 'utf-8');
+  tmpFiles.push(p);
+  return p;
+}
+
+beforeAll(async () => {
+  // loadSession ignores maxAge — just checks if session file exists
+  const session = await loadSession();
+  if (!session) return;
+  hasSession = true;
+
+  client = new NotebookClient();
+  await client.connect({ transport: 'auto' });
+
+  const { notebookId } = await client.createNotebook();
+  testNotebookId = notebookId;
+});
+
+afterAll(async () => {
+  if (client && testNotebookId) {
+    try { await client.deleteNotebook(testNotebookId); } catch { /* best-effort */ }
+  }
+  if (client) await client.disconnect();
+  for (const f of tmpFiles) {
+    try { unlinkSync(f); } catch { /* ignore */ }
+  }
+});
+
+describe('E2E addFileSource', () => {
+  it('should upload a .txt file and get a sourceId', async () => {
+    if (!hasSession || !testNotebookId) return expect(true).toBe(true);
+
+    const filePath = createTmpFile('test.txt',
+      'TypeScript is a strongly typed programming language that builds on JavaScript. '
+      + 'It was developed by Microsoft and first released in 2012. '
+      + 'TypeScript adds optional static typing, classes, and interfaces to JavaScript. '
+      + 'It is designed for the development of large applications.',
+    );
+
+    const result = await client.addFileSource(testNotebookId, filePath);
+    expect(result.sourceId).toBeTruthy();
+    expect(result.title).toBeTruthy();
+  }, 60_000);
+
+  it('should show uploaded file source in notebook detail', async () => {
+    if (!hasSession || !testNotebookId) return expect(true).toBe(true);
+
+    // Poll until the file source is processed
+    let ready = false;
+    for (let i = 0; i < 20; i++) {
+      const detail = await client.getNotebookDetail(testNotebookId);
+      if (detail.sources.length >= 1 && detail.sources.some((s) => s.wordCount && s.wordCount > 0)) {
+        ready = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+    expect(ready).toBe(true);
+  }, 120_000);
+
+  it('should upload a .md file', async () => {
+    if (!hasSession || !testNotebookId) return expect(true).toBe(true);
+
+    const filePath = createTmpFile('test.md',
+      '# Markdown Test\n\n'
+      + 'This is a test markdown file for NotebookLM file upload.\n\n'
+      + '## Section 1\n\nSome content about programming languages.\n\n'
+      + '## Section 2\n\nMore content about software engineering.\n',
+    );
+
+    const result = await client.addFileSource(testNotebookId, filePath);
+    expect(result.sourceId).toBeTruthy();
+  }, 60_000);
+});

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -77,6 +77,16 @@ describe('parseAddSource', () => {
     expect(result.sourceId).toBe('source-uuid-123');
     expect(result.title).toBe('Wikipedia: TypeScript');
   });
+
+  it('extracts source ID from file source RPC (no title)', () => {
+    // ADD_SOURCE_FILE (o4cbdc) returns sourceId but no title
+    const raw = wrapEnvelope('o4cbdc', [
+      [[['file-source-uuid-789']]],
+    ]);
+    const result = parseAddSource(raw);
+    expect(result.sourceId).toBe('file-source-uuid-789');
+    expect(result.title).toBe('');
+  });
 });
 
 describe('parseGenerateArtifact', () => {


### PR DESCRIPTION
## Summary

- Implements `addFileSource(notebookId, filePath)` for uploading local files (PDF, docx, txt, md, csv, pptx, epub, mp3, wav, images, etc.)
- Uses Google's Scotty 3-step resumable upload protocol (pure HTTP, no browser UI automation)
- Works with **all transports** (curl-impersonate, tls-client, http, browser) — not browser-only
- Adds `--file <path>` CLI option for all source-accepting commands (`audio`, `analyze`, etc.)

### Protocol (reverse-engineered from notebooklm-py)

1. **RPC `o4cbdc`** (ADD_SOURCE_FILE) — registers file intent, returns `sourceId`
2. **POST `/upload/_/`** — initiates Scotty resumable session, returns upload URL via `x-goog-upload-url` header
3. **POST upload URL** — streams raw file bytes with `x-goog-upload-command: upload, finalize`

### API

```ts
const { sourceId, title } = await client.addFileSource(notebookId, '/path/to/paper.pdf');
```

```bash
npx notebooklm audio --file ./paper.pdf -o ./output
```

## Test plan

- [x] Unit test: `parseAddSource` handles file source RPC response (no title)
- [x] E2E: upload `.txt` file → verify sourceId returned
- [x] E2E: poll notebook detail → verify source processed (wordCount > 0)
- [x] E2E: upload `.md` file → verify sourceId returned
- [x] All 82 existing unit tests pass
- [x] 3 consecutive e2e runs all green

Closes #2