### PR TITLE
refactor: split client.ts into focused modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,15 +234,15 @@ const { text } = await client.sendChat(notebookId, 'Summarize', detail.sources.m
 // Generate artifacts with typed options
 const sourceIds = detail.sources.map(s => s.id);
 
-await client.generateArtifact(notebookId, 1, sourceIds, {
+await client.generateArtifact(notebookId, sourceIds, {
   type: 'audio', format: 'debate', length: 'short', instructions: 'Focus on key points',
 });
 
-await client.generateArtifact(notebookId, 2, sourceIds, {
+await client.generateArtifact(notebookId, sourceIds, {
   type: 'report', template: 'study_guide', instructions: 'Include diagrams',
 });
 
-await client.generateArtifact(notebookId, 8, sourceIds, {
+await client.generateArtifact(notebookId, sourceIds, {
   type: 'slide_deck', format: 'presenter', length: 'short',
 });
 
@@ -281,7 +281,7 @@ await client.getStudioConfig(notebookId)              // → StudioConfig
 await client.getAccountInfo()                          // → AccountInfo
 
 // Artifacts (low-level)
-await client.generateArtifact(notebookId, type, sourceIds, options)
+await client.generateArtifact(notebookId, sourceIds, options)
 await client.getArtifacts(notebookId)                 // → ArtifactInfo[]
 await client.getInteractiveHtml(artifactId)            // → string (HTML)
 await client.downloadAudio(downloadUrl, outputDir)    // → filePath
@@ -581,15 +581,15 @@ const { text } = await client.sendChat(notebookId, '帮我总结', detail.source
 // 生成产物（带类型化选项）
 const sourceIds = detail.sources.map(s => s.id);
 
-await client.generateArtifact(notebookId, 1, sourceIds, {
+await client.generateArtifact(notebookId, sourceIds, {
   type: 'audio', format: 'debate', length: 'short', instructions: '关注要点',
 });
 
-await client.generateArtifact(notebookId, 2, sourceIds, {
+await client.generateArtifact(notebookId, sourceIds, {
   type: 'report', template: 'study_guide', instructions: '包含图表',
 });
 
-await client.generateArtifact(notebookId, 8, sourceIds, {
+await client.generateArtifact(notebookId, sourceIds, {
   type: 'slide_deck', format: 'presenter', length: 'short',
 });
 
@@ -628,7 +628,7 @@ await client.getStudioConfig(notebookId)              // → StudioConfig
 await client.getAccountInfo()                          // → AccountInfo
 
 // 产物（底层）
-await client.generateArtifact(notebookId, type, sourceIds, options)
+await client.generateArtifact(notebookId, sourceIds, options)
 await client.getArtifacts(notebookId)                 // → ArtifactInfo[]
 await client.getInteractiveHtml(artifactId)            // → string (HTML)
 await client.downloadAudio(downloadUrl, outputDir)    // → filePath

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,647 @@
+/**
+ * Low-level API operations — stateless functions extracted from NotebookClient.
+ *
+ * Every function takes a `RpcCaller` (matching callBatchExecute signature)
+ * so there is no circular dependency on the client class.
+ */
+
+import { statSync, readFileSync } from 'node:fs';
+import { resolve, basename } from 'node:path';
+// SessionError used by addFileSource callers — not directly here
+import { parseEnvelopes } from './boq-parser.js';
+import { NB_RPC, NB_URLS, DEFAULT_USER_CONFIG, PLATFORM_WEB } from './rpc-ids.js';
+import { buildArtifactPayload } from './artifact-payloads.js';
+import {
+  parseCreateNotebook,
+  parseListNotebooks,
+  parseNotebookDetail,
+  parseAddSource,
+  parseGenerateArtifact,
+  parseArtifacts,
+  parseChatStream,
+  parseSourceSummary,
+  parseStudioConfig,
+  parseQuota,
+  parseResearchResults,
+} from './parser.js';
+import type { RpcCaller } from './download.js';
+import type {
+  NotebookRpcSession,
+  NotebookInfo,
+  StudioConfig,
+  AccountInfo,
+  SourceInfo,
+  ArtifactInfo,
+  ResearchResult,
+  ArtifactGenerateOptions,
+  LegacyArtifactOptions,
+} from './types.js';
+
+// Re-export for convenience
+export type { RpcCaller } from './download.js';
+
+// ── Notebooks ──
+
+export async function createNotebook(callRpc: RpcCaller): Promise<{ notebookId: string }> {
+  const raw = await callRpc(
+    NB_RPC.CREATE_NOTEBOOK,
+    ['', null, null, [...PLATFORM_WEB], [1, null, null, null, null, null, null, null, null, null, [1]]],
+    '/',
+  );
+  return parseCreateNotebook(raw);
+}
+
+export async function listNotebooks(callRpc: RpcCaller): Promise<NotebookInfo[]> {
+  const raw = await callRpc(NB_RPC.LIST_NOTEBOOKS, [null, 1, null, [...PLATFORM_WEB]], '/');
+  return parseListNotebooks(raw);
+}
+
+export async function getNotebookDetail(
+  callRpc: RpcCaller,
+  notebookId: string,
+): Promise<{ title: string; sources: SourceInfo[] }> {
+  const raw = await callRpc(
+    NB_RPC.GET_NOTEBOOK,
+    [notebookId, null, [...PLATFORM_WEB], null, 1],
+    `/notebook/${notebookId}`,
+  );
+  return parseNotebookDetail(raw);
+}
+
+export async function deleteNotebook(callRpc: RpcCaller, notebookId: string): Promise<void> {
+  await callRpc(NB_RPC.DELETE_NOTEBOOK, [[notebookId], [...PLATFORM_WEB]], '/');
+}
+
+export async function renameNotebook(
+  callRpc: RpcCaller,
+  notebookId: string,
+  newTitle: string,
+): Promise<void> {
+  await callRpc(
+    NB_RPC.RENAME_NOTEBOOK,
+    [notebookId, [[null, null, null, [null, newTitle]]]],
+    '/',
+  );
+}
+
+// ── Sources ──
+
+export async function addUrlSource(
+  callRpc: RpcCaller,
+  notebookId: string,
+  url: string,
+): Promise<{ sourceId: string; title: string }> {
+  const raw = await callRpc(
+    NB_RPC.ADD_SOURCE,
+    [
+      [[null, null, [url], null, null, null, null, null, null, null, 1]],
+      notebookId,
+      [...PLATFORM_WEB],
+      [1, null, null, null, null, null, null, null, null, null, [1]],
+    ],
+    `/notebook/${notebookId}`,
+  );
+  return parseAddSource(raw);
+}
+
+export async function addTextSource(
+  callRpc: RpcCaller,
+  notebookId: string,
+  title: string,
+  content: string,
+): Promise<{ sourceId: string; title: string }> {
+  const raw = await callRpc(
+    NB_RPC.ADD_SOURCE,
+    [
+      [[null, [title, content], null, 2, null, null, null, null, null, null, 1]],
+      notebookId,
+      [...PLATFORM_WEB],
+      [1, null, null, null, null, null, null, null, null, null, [1]],
+    ],
+    `/notebook/${notebookId}`,
+  );
+  return parseAddSource(raw);
+}
+
+/** Dependencies for file upload (Scotty protocol). */
+export interface FileUploadDeps {
+  session: NotebookRpcSession;
+  proxy?: string;
+}
+
+/**
+ * Upload a local file as a source. Uses Google's Scotty resumable upload protocol.
+ * Supported: pdf, txt, md, docx, csv, pptx, epub, mp3, wav, m4a, png, jpg, gif, etc.
+ */
+export async function addFileSource(
+  callRpc: RpcCaller,
+  deps: FileUploadDeps,
+  notebookId: string,
+  filePath: string,
+): Promise<{ sourceId: string; title: string }> {
+  const absPath = resolve(filePath);
+  const stat = statSync(absPath);
+  if (!stat.isFile()) throw new Error(`Not a file: ${absPath}`);
+  const fileName = basename(absPath);
+  const fileSize = stat.size;
+
+  const raw = await callRpc(
+    NB_RPC.ADD_SOURCE_FILE,
+    [
+      [[fileName]],
+      notebookId,
+      [...PLATFORM_WEB],
+      [1, null, null, null, null, null, null, null, null, null, [1]],
+    ],
+    `/notebook/${notebookId}`,
+  );
+  const { sourceId } = parseAddSource(raw);
+  if (!sourceId) throw new Error('Failed to register file source — no sourceId returned');
+
+  const fileBuffer = readFileSync(absPath);
+  await scottyUpload(deps, notebookId, fileName, sourceId, fileSize, fileBuffer);
+
+  return { sourceId, title: fileName };
+}
+
+/**
+ * Execute Scotty resumable upload: initiate session → upload bytes.
+ */
+async function scottyUpload(
+  deps: FileUploadDeps,
+  notebookId: string,
+  fileName: string,
+  sourceId: string,
+  fileSize: number,
+  fileBuffer: Buffer,
+): Promise<void> {
+  const { request: undiciRequest, Agent, ProxyAgent } = await import('undici');
+  const { CHROME_CIPHERS } = await import('./tls-config.js');
+  const { session, proxy } = deps;
+
+  const baseHeaders: Record<string, string> = {
+    'Accept': '*/*',
+    'Cookie': session.cookies,
+    'Origin': 'https://notebooklm.google.com',
+    'Referer': 'https://notebooklm.google.com/',
+    'User-Agent': session.userAgent,
+    'x-goog-authuser': '0',
+  };
+
+  let dispatcher: InstanceType<typeof Agent> | InstanceType<typeof ProxyAgent>;
+  if (proxy) {
+    dispatcher = new ProxyAgent({
+      uri: proxy,
+      requestTls: { ciphers: CHROME_CIPHERS, minVersion: 'TLSv1.2', maxVersion: 'TLSv1.3' },
+    });
+  } else {
+    dispatcher = new Agent({
+      connect: {
+        ciphers: CHROME_CIPHERS,
+        minVersion: 'TLSv1.2',
+        maxVersion: 'TLSv1.3',
+        ALPNProtocols: ['h2', 'http/1.1'],
+      } as Record<string, unknown>,
+    });
+  }
+
+  const doPost = async (
+    url: string, headers: Record<string, string>, body: string | Buffer,
+  ): Promise<{ status: number; headers: Record<string, string>; body: string }> => {
+    const response = await undiciRequest(url, {
+      method: 'POST', headers, body, dispatcher,
+      headersTimeout: 300_000,
+      bodyTimeout: 300_000,
+    });
+    const responseBody = await response.body.text();
+    const responseHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(response.headers)) {
+      if (typeof value === 'string') {
+        responseHeaders[key] = value;
+      } else if (Array.isArray(value) && value[0] != null) {
+        responseHeaders[key] = value[0];
+      }
+    }
+    return { status: response.statusCode, headers: responseHeaders, body: responseBody };
+  };
+
+  try {
+    const initResp = await doPost(`${NB_URLS.UPLOAD}?authuser=0`, {
+      ...baseHeaders,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      'x-goog-upload-command': 'start',
+      'x-goog-upload-header-content-length': String(fileSize),
+      'x-goog-upload-protocol': 'resumable',
+    }, JSON.stringify({ PROJECT_ID: notebookId, SOURCE_NAME: fileName, SOURCE_ID: sourceId }));
+
+    const uploadUrl = initResp.headers['x-goog-upload-url'];
+    if (!uploadUrl) {
+      throw new Error(`Upload session initiation failed (HTTP ${initResp.status}): no x-goog-upload-url in response`);
+    }
+
+    const uploadResp = await doPost(uploadUrl, {
+      ...baseHeaders,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+      'x-goog-upload-command': 'upload, finalize',
+      'x-goog-upload-offset': '0',
+    }, fileBuffer);
+
+    if (uploadResp.status < 200 || uploadResp.status >= 300) {
+      throw new Error(`File upload failed (HTTP ${uploadResp.status}): ${uploadResp.body.slice(0, 200)}`);
+    }
+  } finally {
+    await dispatcher.close();
+  }
+}
+
+export async function deleteSource(callRpc: RpcCaller, sourceId: string): Promise<void> {
+  await callRpc(NB_RPC.DELETE_SOURCE, [[[sourceId]], [...PLATFORM_WEB]]);
+}
+
+export async function getSourceSummary(
+  callRpc: RpcCaller,
+  sourceId: string,
+): Promise<{ summary: string }> {
+  const raw = await callRpc(NB_RPC.GET_SOURCE_SUMMARY, [[[[sourceId]]]]);
+  return { summary: parseSourceSummary(raw).summary };
+}
+
+export async function renameSource(
+  callRpc: RpcCaller,
+  notebookId: string,
+  sourceId: string,
+  newTitle: string,
+): Promise<void> {
+  await callRpc(
+    NB_RPC.UPDATE_SOURCE,
+    [null, [sourceId], [[[newTitle]]]],
+    `/notebook/${notebookId}`,
+  );
+}
+
+export async function refreshSource(
+  callRpc: RpcCaller,
+  notebookId: string,
+  sourceId: string,
+): Promise<void> {
+  await callRpc(
+    NB_RPC.REFRESH_SOURCE,
+    [null, [sourceId], [...PLATFORM_WEB]],
+    `/notebook/${notebookId}`,
+  );
+}
+
+// ── Notes ──
+
+export async function listNotes(
+  callRpc: RpcCaller,
+  notebookId: string,
+): Promise<Array<{ id: string; title: string; content: string }>> {
+  const raw = await callRpc(NB_RPC.GET_NOTES, [notebookId], `/notebook/${notebookId}`);
+  const envelopes = parseEnvelopes(raw);
+  const first = envelopes[0];
+  if (!Array.isArray(first) || !Array.isArray(first[0])) return [];
+
+  const notes: Array<{ id: string; title: string; content: string }> = [];
+  for (const item of first[0]) {
+    if (!Array.isArray(item) || typeof item[0] !== 'string') continue;
+    if (item[1] === null && item[2] === 2) continue;
+    const content = typeof item[1] === 'string'
+      ? item[1]
+      : (Array.isArray(item[1]) && typeof item[1][1] === 'string' ? item[1][1] : '');
+    if (content.includes('"children":') || content.includes('"nodes":')) continue;
+
+    let title = '';
+    if (Array.isArray(item[1]) && typeof item[1][4] === 'string') {
+      title = item[1][4];
+    }
+    notes.push({ id: item[0], title, content });
+  }
+  return notes;
+}
+
+export async function createNote(
+  callRpc: RpcCaller,
+  notebookId: string,
+  title = 'New Note',
+  content = '',
+): Promise<{ noteId: string }> {
+  const raw = await callRpc(
+    NB_RPC.CREATE_NOTE,
+    [notebookId, '', [1], null, 'New Note'],
+    `/notebook/${notebookId}`,
+  );
+  const envelopes = parseEnvelopes(raw);
+  const first = envelopes[0];
+  let noteId = '';
+  if (Array.isArray(first) && Array.isArray(first[0]) && typeof first[0][0] === 'string') {
+    noteId = first[0][0];
+  } else if (Array.isArray(first) && typeof first[0] === 'string') {
+    noteId = first[0];
+  }
+  if (noteId && (title !== 'New Note' || content)) {
+    await updateNote(callRpc, notebookId, noteId, content, title);
+  }
+  return { noteId };
+}
+
+export async function updateNote(
+  callRpc: RpcCaller,
+  notebookId: string,
+  noteId: string,
+  content: string,
+  title: string,
+): Promise<void> {
+  await callRpc(
+    NB_RPC.UPDATE_NOTE,
+    [notebookId, noteId, [[[content, title, [], 0]]]],
+    `/notebook/${notebookId}`,
+  );
+}
+
+export async function deleteNote(
+  callRpc: RpcCaller,
+  notebookId: string,
+  noteId: string,
+): Promise<void> {
+  await callRpc(NB_RPC.DELETE_NOTE, [notebookId, null, [noteId]], `/notebook/${notebookId}`);
+}
+
+// ── Sharing ──
+
+export async function getShareStatus(
+  callRpc: RpcCaller,
+  notebookId: string,
+): Promise<unknown> {
+  const raw = await callRpc(
+    NB_RPC.GET_SHARE_STATUS,
+    [notebookId, [...PLATFORM_WEB]],
+    `/notebook/${notebookId}`,
+  );
+  return parseEnvelopes(raw)[0] ?? null;
+}
+
+export async function shareNotebook(
+  callRpc: RpcCaller,
+  notebookId: string,
+  isPublic: boolean,
+): Promise<void> {
+  const access = isPublic ? 1 : 0;
+  await callRpc(
+    NB_RPC.SHARE_NOTEBOOK,
+    [[[notebookId, null, [access], [access, '']]], 1, null, [...PLATFORM_WEB]],
+    `/notebook/${notebookId}`,
+  );
+}
+
+export async function shareNotebookWithUser(
+  callRpc: RpcCaller,
+  notebookId: string,
+  email: string,
+  permission: 'editor' | 'viewer' = 'viewer',
+  options?: { notify?: boolean; message?: string },
+): Promise<void> {
+  const permCode = permission === 'editor' ? 2 : 3;
+  const notify = options?.notify !== false ? 1 : 0;
+  const msg = options?.message ?? '';
+  const msgFlag = msg ? 0 : 1;
+  await callRpc(
+    NB_RPC.SHARE_NOTEBOOK,
+    [[[notebookId, [[email, null, permCode]], null, [msgFlag, msg]]], notify, null, [...PLATFORM_WEB]],
+    `/notebook/${notebookId}`,
+  );
+}
+
+// ── Settings ──
+
+export async function getOutputLanguage(callRpc: RpcCaller): Promise<string | null> {
+  const raw = await callRpc(
+    NB_RPC.GET_ACCOUNT_INFO,
+    [null, [1, null, null, null, null, null, null, null, null, null, [1]]],
+    '/',
+  );
+  const envelopes = parseEnvelopes(raw);
+  const result = envelopes[0];
+  if (!Array.isArray(result)) return null;
+  const outer = Array.isArray(result[0]) ? result[0] as unknown[] : null;
+  if (!outer) return null;
+  const settings = Array.isArray(outer[2]) ? outer[2] as unknown[] : null;
+  if (!settings) return null;
+  const langArr = Array.isArray(settings[4]) ? settings[4] as unknown[] : null;
+  return langArr && typeof langArr[0] === 'string' ? langArr[0] : null;
+}
+
+export async function setOutputLanguage(callRpc: RpcCaller, language: string): Promise<void> {
+  await callRpc(NB_RPC.SET_USER_SETTINGS, [[[null, [[null, null, null, null, [language]]]]]], '/');
+}
+
+// ── Artifacts ──
+
+export async function renameArtifact(
+  callRpc: RpcCaller,
+  artifactId: string,
+  newTitle: string,
+): Promise<void> {
+  await callRpc(NB_RPC.RENAME_ARTIFACT, [artifactId, newTitle]);
+}
+
+export async function getInteractiveHtml(
+  callRpc: RpcCaller,
+  artifactId: string,
+): Promise<string> {
+  const raw = await callRpc(NB_RPC.GET_INTERACTIVE_HTML, [artifactId]);
+  const envelopes = parseEnvelopes(raw);
+  const first = envelopes[0];
+  if (typeof first === 'string') return first;
+  if (Array.isArray(first)) {
+    if (typeof first[0] === 'string') return first[0];
+    const flat = Array.isArray(first[0]) ? first[0] as unknown[] : first;
+    for (const el of flat) {
+      if (typeof el === 'string' && el.length > 200 && el.includes('<')) return el;
+    }
+  }
+  return '';
+}
+
+export async function generateArtifact(
+  callRpc: RpcCaller,
+  notebookId: string,
+  _type: number,
+  sourceIds: string[],
+  sessionLanguage: string,
+  options?: ArtifactGenerateOptions | LegacyArtifactOptions,
+): Promise<{ artifactId: string; title: string }> {
+  const sidsTriple = sourceIds.map((id) => [[id]]);
+  const sidsDouble = sourceIds.map((id) => [id]);
+
+  let innerPayload: unknown[];
+
+  if (options && 'type' in options) {
+    const opts = { ...options } as ArtifactGenerateOptions & { language?: string };
+    if (!opts.language) opts.language = sessionLanguage;
+    innerPayload = buildArtifactPayload(sidsTriple, sidsDouble, opts);
+  } else {
+    const legacy = options as LegacyArtifactOptions | undefined;
+    innerPayload = buildArtifactPayload(sidsTriple, sidsDouble, {
+      type: 'audio',
+      instructions: legacy?.customPrompt ?? undefined,
+      language: legacy?.language ?? sessionLanguage,
+    });
+  }
+
+  const raw = await callRpc(
+    NB_RPC.GENERATE_ARTIFACT,
+    [[...DEFAULT_USER_CONFIG], notebookId, innerPayload],
+    `/notebook/${notebookId}`,
+  );
+  return parseGenerateArtifact(raw);
+}
+
+export async function getArtifacts(
+  callRpc: RpcCaller,
+  notebookId: string,
+): Promise<ArtifactInfo[]> {
+  const raw = await callRpc(
+    NB_RPC.GET_ARTIFACTS_FILTERED,
+    [
+      [...DEFAULT_USER_CONFIG],
+      notebookId,
+      'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"',
+    ],
+    `/notebook/${notebookId}`,
+  );
+  return parseArtifacts(raw);
+}
+
+export async function deleteArtifact(callRpc: RpcCaller, artifactId: string): Promise<void> {
+  await callRpc(NB_RPC.DELETE_ARTIFACT, [[...DEFAULT_USER_CONFIG], artifactId]);
+}
+
+// ── Research ──
+
+export async function createWebSearch(
+  callRpc: RpcCaller,
+  notebookId: string,
+  query: string,
+  mode: 'fast' | 'deep' = 'fast',
+): Promise<{ researchId: string; artifactId?: string }> {
+  if (mode === 'deep') {
+    return createDeepResearch(callRpc, notebookId, query);
+  }
+
+  const raw = await callRpc(
+    NB_RPC.CREATE_WEB_SEARCH,
+    [[query, 1], null, 1, notebookId],
+    `/notebook/${notebookId}`,
+  );
+  const envelopes = parseEnvelopes(raw);
+  const first = envelopes[0];
+  const taskId = Array.isArray(first) && typeof first[0] === 'string' ? first[0] : '';
+  if (!taskId) {
+    console.error('NotebookLM: Warning — failed to parse researchId from fast research response');
+  }
+  return { researchId: taskId };
+}
+
+async function createDeepResearch(
+  callRpc: RpcCaller,
+  notebookId: string,
+  query: string,
+): Promise<{ researchId: string; artifactId?: string }> {
+  const raw = await callRpc(
+    NB_RPC.CREATE_DEEP_RESEARCH,
+    [null, [1], [query, 1], 5, notebookId],
+    `/notebook/${notebookId}`,
+  );
+  const envelopes = parseEnvelopes(raw);
+  const first = envelopes[0];
+  const taskId = Array.isArray(first) && typeof first[0] === 'string' ? first[0] : '';
+  const reportId = Array.isArray(first) && typeof first[1] === 'string' ? first[1] : undefined;
+  if (!taskId) {
+    console.error('NotebookLM: Warning — failed to parse researchId from deep research response');
+  }
+  return { researchId: taskId, artifactId: reportId };
+}
+
+export async function pollResearchResults(
+  callRpc: RpcCaller,
+  notebookId: string,
+  timeoutMs = 120_000,
+): Promise<{ results: ResearchResult[]; report?: string }> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const raw = await callRpc(
+      NB_RPC.POLL_RESEARCH,
+      [null, null, notebookId],
+      `/notebook/${notebookId}`,
+    );
+    const parsed = parseResearchResults(raw);
+    if (parsed.status >= 2) {
+      console.error(`NotebookLM: Research completed — ${parsed.results.length} sources${parsed.report ? ' + report' : ''}`);
+      return { results: parsed.results, report: parsed.report };
+    }
+    await new Promise(r => setTimeout(r, 5000));
+  }
+  console.error('NotebookLM: Research poll timed out');
+  return { results: [] };
+}
+
+export async function importResearch(
+  callRpc: RpcCaller,
+  notebookId: string,
+  researchId: string,
+  results: ResearchResult[],
+  report?: string,
+): Promise<void> {
+  const sources: unknown[][] = [];
+
+  if (report) {
+    sources.push([null, ['Deep Research Report', report], null, 3, null, null, null, null, null, null, 3]);
+  }
+
+  for (const r of results) {
+    sources.push([null, null, [r.url, r.title], null, null, null, null, null, null, null, 2]);
+  }
+
+  if (sources.length === 0) return;
+
+  await callRpc(
+    NB_RPC.IMPORT_RESEARCH,
+    [null, [1], researchId, notebookId, sources],
+    `/notebook/${notebookId}`,
+  );
+  console.error(`NotebookLM: Imported ${sources.length} research sources`);
+}
+
+export async function getStudioConfig(
+  callRpc: RpcCaller,
+  notebookId: string,
+): Promise<StudioConfig> {
+  const raw = await callRpc(
+    NB_RPC.GET_STUDIO_CONFIG,
+    [[...DEFAULT_USER_CONFIG], notebookId],
+    `/notebook/${notebookId}`,
+  );
+  return parseStudioConfig(raw);
+}
+
+export async function getAccountInfo(callRpc: RpcCaller): Promise<AccountInfo> {
+  const raw = await callRpc(NB_RPC.GET_ACCOUNT_INFO, [[...DEFAULT_USER_CONFIG]], '/');
+  return parseQuota(raw);
+}
+
+// ── Chat ──
+
+export async function sendChat(
+  callChatStream: (notebookId: string, message: string, sourceIds: string[]) => Promise<string>,
+  notebookId: string,
+  message: string,
+  sourceIds: string[],
+): Promise<{ text: string; threadId: string }> {
+  const raw = await callChatStream(notebookId, message, sourceIds);
+  return parseChatStream(raw);
+}
+
+export async function deleteChatThread(callRpc: RpcCaller, threadId: string): Promise<void> {
+  await callRpc(NB_RPC.DELETE_CHAT_THREAD, [[], threadId, null, 1]);
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -466,7 +466,6 @@ export async function getInteractiveHtml(
 export async function generateArtifact(
   callRpc: RpcCaller,
   notebookId: string,
-  _type: number,
   sourceIds: string[],
   sessionLanguage: string,
   options?: ArtifactGenerateOptions | LegacyArtifactOptions,

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,33 +9,30 @@
  *   - 'auto':             Best available non-browser transport
  */
 
-import { mkdirSync, writeFileSync, statSync, readFileSync } from 'node:fs';
-import { join, resolve, basename } from 'node:path';
 import { type Page } from 'puppeteer-core';
 import { SessionError, UserDisplayableError } from './errors.js';
-import { humanSleep, jitteredIncrement } from './utils/humanize.js';
-import { parseEnvelopes } from './boq-parser.js';
-import { NB_RPC, NB_URLS, DEFAULT_USER_CONFIG, PLATFORM_WEB, ARTIFACT_TYPE } from './rpc-ids.js';
-import { buildArtifactPayload } from './artifact-payloads.js';
+import { jitteredIncrement } from './utils/humanize.js';
+import { NB_URLS } from './rpc-ids.js';
 import { loadNbRpcIds } from './rpc-config.js';
 import { BrowserTransport } from './transport-browser.js';
 import { detectBestTier, createTransport, TIER_LABELS } from './transport-resolver.js';
 import type { TransportTier } from './transport-resolver.js';
 import { saveSession, loadSession, refreshTokens } from './session-store.js';
 import type { Transport } from './transport.js';
+import { downloadFileHttp, downloadAudioBrowser } from './download.js';
+import * as api from './api.js';
 import {
-  parseCreateNotebook,
-  parseListNotebooks,
-  parseNotebookDetail,
-  parseAddSource,
-  parseGenerateArtifact,
-  parseArtifacts,
-  parseChatStream,
-  parseSourceSummary,
-  parseStudioConfig,
-  parseQuota,
-  parseResearchResults,
-} from './parser.js';
+  runAudioOverview as _runAudioOverview,
+  runMindMap as _runMindMap,
+  runFlashcards as _runFlashcards,
+  runAnalyze as _runAnalyze,
+  runReport as _runReport,
+  runVideo as _runVideo,
+  runQuiz as _runQuiz,
+  runInfographic as _runInfographic,
+  runSlideDeck as _runSlideDeck,
+  runDataTable as _runDataTable,
+} from './workflows.js';
 import type {
   NotebookSession,
   NotebookRpcSession,
@@ -45,7 +42,6 @@ import type {
   QuotaInfo,
   SourceInfo,
   ArtifactInfo,
-  SourceInput,
   AudioOverviewOptions,
   AudioOverviewResult,
   MindMapOptions,
@@ -96,6 +92,8 @@ export class NotebookClient {
   private proxy?: string;
   private reqCounter = 100000;
   private activeNotebookId = '';
+  private chatThreadId = '';
+  private chatHistory: Array<[string, null, number]> = [];
 
   // ── Lifecycle ──
 
@@ -115,7 +113,6 @@ export class NotebookClient {
     await bt.init();
     this.transport = bt;
 
-    // Auto-save session for later HTTP use
     try {
       const session = await bt.exportSession();
       const path = await saveSession(session, config.sessionPath);
@@ -128,7 +125,6 @@ export class NotebookClient {
   private async connectHeadless(config: ConnectOptions): Promise<void> {
     let session = config.session ?? null;
 
-    // Try NOTEBOOKLM_AUTH_JSON env var (for Docker/CI)
     if (!session && process.env['NOTEBOOKLM_AUTH_JSON']) {
       try {
         session = JSON.parse(process.env['NOTEBOOKLM_AUTH_JSON']) as NotebookRpcSession;
@@ -164,12 +160,10 @@ export class NotebookClient {
       }
     };
 
-    // Determine transport tier
     let tier: TransportTier;
     if (this.transportMode === 'auto') {
       tier = await detectBestTier({ curlBinaryPath: config.curlBinaryPath });
     } else {
-      // Direct tier selection: 'curl-impersonate' | 'tls-client' | 'http'
       tier = this.transportMode as TransportTier;
     }
 
@@ -181,7 +175,6 @@ export class NotebookClient {
       onSessionExpired,
     });
 
-    // Update transportMode to actual tier used (for getTransportMode())
     this.transportMode = tier;
     console.error(`NotebookLM: Connected via ${TIER_LABELS[tier]} (bl=${session.bl.slice(0, 40)}...)`);
   }
@@ -210,7 +203,6 @@ export class NotebookClient {
     return this.transport.getSession();
   }
 
-  /** Get the active Puppeteer Page (only available in browser mode). */
   getActivePage(): Page | null {
     if (this.transport instanceof BrowserTransport) {
       return this.transport.getPage();
@@ -218,15 +210,18 @@ export class NotebookClient {
     return null;
   }
 
-  /** Get current transport mode. */
   getTransportMode(): TransportMode {
     return this.transportMode;
   }
 
-  /**
-   * Export current session to disk for later HTTP mode use.
-   * Only meaningful in browser mode.
-   */
+  getProxy(): string | undefined {
+    return this.proxy;
+  }
+
+  ensureConnected(): void {
+    if (!this.transport) throw new SessionError('NotebookLM client not connected');
+  }
+
   async exportSession(path?: string): Promise<string> {
     if (!(this.transport instanceof BrowserTransport)) {
       throw new Error('exportSession is only available in browser mode');
@@ -291,9 +286,6 @@ export class NotebookClient {
     }
   }
 
-  private chatThreadId = '';
-  private chatHistory: Array<[string, null, number]> = [];
-
   async callChatStream(notebookId: string, message: string, sourceIds: string[]): Promise<string> {
     if (!this.transport) throw new SessionError('Not connected');
 
@@ -345,356 +337,88 @@ export class NotebookClient {
     return false;
   }
 
-  // ── Low-level API Methods ──
+  // ── Bound RPC caller for api.ts functions ──
+
+  private get rpc() {
+    return this.callBatchExecute.bind(this);
+  }
+
+  // ── Low-level API (delegated to api.ts) ──
 
   async createNotebook(): Promise<{ notebookId: string }> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.CREATE_NOTEBOOK,
-      ['', null, null, [...PLATFORM_WEB], [1, null, null, null, null, null, null, null, null, null, [1]]],
-      '/',
-    );
-    const result = parseCreateNotebook(raw);
+    const result = await api.createNotebook(this.rpc);
     this.activeNotebookId = result.notebookId;
     return result;
   }
 
   async listNotebooks(): Promise<NotebookInfo[]> {
-    const raw = await this.callBatchExecute(NB_RPC.LIST_NOTEBOOKS, [null, 1, null, [...PLATFORM_WEB]], '/');
-    return parseListNotebooks(raw);
+    return api.listNotebooks(this.rpc);
   }
 
   async getNotebookDetail(notebookId: string): Promise<{ title: string; sources: SourceInfo[] }> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.GET_NOTEBOOK,
-      [notebookId, null, [...PLATFORM_WEB], null, 1],
-      `/notebook/${notebookId}`,
-    );
-    return parseNotebookDetail(raw);
+    return api.getNotebookDetail(this.rpc, notebookId);
   }
 
   async deleteNotebook(notebookId: string): Promise<void> {
-    await this.callBatchExecute(NB_RPC.DELETE_NOTEBOOK, [[notebookId], [...PLATFORM_WEB]], '/');
+    return api.deleteNotebook(this.rpc, notebookId);
   }
 
   async renameNotebook(notebookId: string, newTitle: string): Promise<void> {
-    await this.callBatchExecute(
-      NB_RPC.RENAME_NOTEBOOK,
-      [notebookId, [[null, null, null, [null, newTitle]]]],
-      '/',
-    );
+    return api.renameNotebook(this.rpc, notebookId, newTitle);
   }
 
   async addUrlSource(notebookId: string, url: string): Promise<{ sourceId: string; title: string }> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.ADD_SOURCE,
-      [
-        [[null, null, [url], null, null, null, null, null, null, null, 1]],
-        notebookId,
-        [...PLATFORM_WEB],
-        [1, null, null, null, null, null, null, null, null, null, [1]],
-      ],
-      `/notebook/${notebookId}`,
-    );
-    return parseAddSource(raw);
+    return api.addUrlSource(this.rpc, notebookId, url);
   }
 
   async addTextSource(notebookId: string, title: string, content: string): Promise<{ sourceId: string; title: string }> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.ADD_SOURCE,
-      [
-        [[null, [title, content], null, 2, null, null, null, null, null, null, 1]],
-        notebookId,
-        [...PLATFORM_WEB],
-        [1, null, null, null, null, null, null, null, null, null, [1]],
-      ],
-      `/notebook/${notebookId}`,
-    );
-    return parseAddSource(raw);
+    return api.addTextSource(this.rpc, notebookId, title, content);
   }
 
-  /**
-   * Upload a local file as a source. Works with all transports.
-   *
-   * Uses Google's Scotty resumable upload protocol:
-   *   1. Register file source via RPC (ADD_SOURCE_FILE)
-   *   2. Initiate resumable upload session
-   *   3. Upload raw file bytes
-   *
-   * Supported: pdf, txt, md, docx, csv, pptx, epub, mp3, wav, m4a, png, jpg, gif, etc.
-   */
   async addFileSource(notebookId: string, filePath: string): Promise<{ sourceId: string; title: string }> {
-    if (!this.transport) throw new SessionError('Not connected');
-
-    const absPath = resolve(filePath);
-    const stat = statSync(absPath);
-    if (!stat.isFile()) throw new Error(`Not a file: ${absPath}`);
-    const fileName = basename(absPath);
-    const fileSize = stat.size;
-
-    // Step 1: Register file source via RPC
-    const raw = await this.callBatchExecute(
-      NB_RPC.ADD_SOURCE_FILE,
-      [
-        [[fileName]],
-        notebookId,
-        [...PLATFORM_WEB],
-        [1, null, null, null, null, null, null, null, null, null, [1]],
-      ],
-      `/notebook/${notebookId}`,
-    );
-    const { sourceId } = parseAddSource(raw);
-    if (!sourceId) throw new Error('Failed to register file source — no sourceId returned');
-
-    // Steps 2+3: Upload file via Scotty resumable protocol
-    const fileBuffer = readFileSync(absPath);
-    await this.scottyUpload(notebookId, fileName, sourceId, fileSize, fileBuffer);
-
-    return { sourceId, title: fileName };
-  }
-
-  /**
-   * Execute Scotty resumable upload: initiate session → upload bytes.
-   * Uses a single HTTP agent for both requests.
-   */
-  private async scottyUpload(
-    notebookId: string, fileName: string, sourceId: string, fileSize: number, fileBuffer: Buffer,
-  ): Promise<void> {
-    const { request: undiciRequest, Agent, ProxyAgent } = await import('undici');
-    const { CHROME_CIPHERS } = await import('./tls-config.js');
+    this.ensureConnected();
     const session = this.transport!.getSession();
-
-    const baseHeaders: Record<string, string> = {
-      'Accept': '*/*',
-      'Cookie': session.cookies,
-      'Origin': 'https://notebooklm.google.com',
-      'Referer': 'https://notebooklm.google.com/',
-      'User-Agent': session.userAgent,
-      'x-goog-authuser': '0',
-    };
-
-    let dispatcher: InstanceType<typeof Agent> | InstanceType<typeof ProxyAgent>;
-    if (this.proxy) {
-      dispatcher = new ProxyAgent({
-        uri: this.proxy,
-        requestTls: { ciphers: CHROME_CIPHERS, minVersion: 'TLSv1.2', maxVersion: 'TLSv1.3' },
-      });
-    } else {
-      dispatcher = new Agent({
-        connect: {
-          ciphers: CHROME_CIPHERS,
-          minVersion: 'TLSv1.2',
-          maxVersion: 'TLSv1.3',
-          ALPNProtocols: ['h2', 'http/1.1'],
-        } as Record<string, unknown>,
-      });
-    }
-
-    const doPost = async (
-      url: string, headers: Record<string, string>, body: string | Buffer,
-    ): Promise<{ status: number; headers: Record<string, string>; body: string }> => {
-      const response = await undiciRequest(url, {
-        method: 'POST', headers, body, dispatcher,
-        headersTimeout: 300_000,
-        bodyTimeout: 300_000,
-      });
-      const responseBody = await response.body.text();
-      const responseHeaders: Record<string, string> = {};
-      for (const [key, value] of Object.entries(response.headers)) {
-        if (typeof value === 'string') {
-          responseHeaders[key] = value;
-        } else if (Array.isArray(value) && value[0] != null) {
-          responseHeaders[key] = value[0];
-        }
-      }
-      return { status: response.statusCode, headers: responseHeaders, body: responseBody };
-    };
-
-    try {
-      // Step 2: Initiate resumable upload session
-      const initResp = await doPost(`${NB_URLS.UPLOAD}?authuser=0`, {
-        ...baseHeaders,
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        'x-goog-upload-command': 'start',
-        'x-goog-upload-header-content-length': String(fileSize),
-        'x-goog-upload-protocol': 'resumable',
-      }, JSON.stringify({ PROJECT_ID: notebookId, SOURCE_NAME: fileName, SOURCE_ID: sourceId }));
-
-      const uploadUrl = initResp.headers['x-goog-upload-url'];
-      if (!uploadUrl) {
-        throw new Error(`Upload session initiation failed (HTTP ${initResp.status}): no x-goog-upload-url in response`);
-      }
-
-      // Step 3: Upload file bytes
-      const uploadResp = await doPost(uploadUrl, {
-        ...baseHeaders,
-        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
-        'x-goog-upload-command': 'upload, finalize',
-        'x-goog-upload-offset': '0',
-      }, fileBuffer);
-
-      if (uploadResp.status < 200 || uploadResp.status >= 300) {
-        throw new Error(`File upload failed (HTTP ${uploadResp.status}): ${uploadResp.body.slice(0, 200)}`);
-      }
-    } finally {
-      await dispatcher.close();
-    }
-  }
-
-  async createWebSearch(notebookId: string, query: string, mode: 'fast' | 'deep' = 'fast'): Promise<{ researchId: string; artifactId?: string }> {
-    if (mode === 'deep') {
-      return this.createDeepResearch(notebookId, query);
-    }
-
-    // Fast Research — uses Ljjv0c
-    const raw = await this.callBatchExecute(
-      NB_RPC.CREATE_WEB_SEARCH,
-      [[query, 1], null, 1, notebookId],
-      `/notebook/${notebookId}`,
-    );
-    const envelopes = parseEnvelopes(raw);
-    // Response: [taskId] or [taskId, reportId]
-    const first = envelopes[0];
-    const taskId = Array.isArray(first) && typeof first[0] === 'string' ? first[0] : '';
-    if (!taskId) {
-      console.error('NotebookLM: Warning — failed to parse researchId from fast research response');
-    }
-    return { researchId: taskId };
-  }
-
-  /**
-   * Deep Research — uses QA9ei RPC (since ~2026-03-19).
-   * Returns researchId + artifactId.
-   */
-  private async createDeepResearch(notebookId: string, query: string): Promise<{ researchId: string; artifactId?: string }> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.CREATE_DEEP_RESEARCH,
-      [null, [1], [query, 1], 5, notebookId],
-      `/notebook/${notebookId}`,
-    );
-    // Response: [taskId, reportId]
-    const envelopes = parseEnvelopes(raw);
-    const first = envelopes[0];
-    const taskId = Array.isArray(first) && typeof first[0] === 'string' ? first[0] : '';
-    const reportId = Array.isArray(first) && typeof first[1] === 'string' ? first[1] : undefined;
-    if (!taskId) {
-      console.error('NotebookLM: Warning — failed to parse researchId from deep research response');
-    }
-    return { researchId: taskId, artifactId: reportId };
+    return api.addFileSource(this.rpc, { session, proxy: this.proxy }, notebookId, filePath);
   }
 
   async deleteSource(sourceId: string): Promise<void> {
-    await this.callBatchExecute(NB_RPC.DELETE_SOURCE, [[[sourceId]], [...PLATFORM_WEB]]);
+    return api.deleteSource(this.rpc, sourceId);
   }
 
   async getSourceSummary(sourceId: string): Promise<{ summary: string }> {
-    const raw = await this.callBatchExecute(NB_RPC.GET_SOURCE_SUMMARY, [[[[sourceId]]]]);
-    const result = parseSourceSummary(raw);
-    return { summary: result.summary };
+    return api.getSourceSummary(this.rpc, sourceId);
   }
 
   async renameSource(notebookId: string, sourceId: string, newTitle: string): Promise<void> {
-    await this.callBatchExecute(
-      NB_RPC.UPDATE_SOURCE,
-      [null, [sourceId], [[[newTitle]]]],
-      `/notebook/${notebookId}`,
-    );
+    return api.renameSource(this.rpc, notebookId, sourceId, newTitle);
   }
 
   async refreshSource(notebookId: string, sourceId: string): Promise<void> {
-    await this.callBatchExecute(
-      NB_RPC.REFRESH_SOURCE,
-      [null, [sourceId], [...PLATFORM_WEB]],
-      `/notebook/${notebookId}`,
-    );
+    return api.refreshSource(this.rpc, notebookId, sourceId);
   }
 
-  // ── Notes ──
-
   async listNotes(notebookId: string): Promise<Array<{ id: string; title: string; content: string }>> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.GET_NOTES,
-      [notebookId],
-      `/notebook/${notebookId}`,
-    );
-    const envelopes = parseEnvelopes(raw);
-    const first = envelopes[0];
-    if (!Array.isArray(first) || !Array.isArray(first[0])) return [];
-
-    const notes: Array<{ id: string; title: string; content: string }> = [];
-    for (const item of first[0]) {
-      if (!Array.isArray(item) || typeof item[0] !== 'string') continue;
-      // Skip deleted notes (status=2): [id, null, 2]
-      if (item[1] === null && item[2] === 2) continue;
-      // Skip mind maps (JSON content with "children"/"nodes")
-      const content = typeof item[1] === 'string'
-        ? item[1]
-        : (Array.isArray(item[1]) && typeof item[1][1] === 'string' ? item[1][1] : '');
-      if (content.includes('"children":') || content.includes('"nodes":')) continue;
-
-      let title = '';
-      if (Array.isArray(item[1]) && typeof item[1][4] === 'string') {
-        title = item[1][4];
-      }
-      notes.push({ id: item[0], title, content });
-    }
-    return notes;
+    return api.listNotes(this.rpc, notebookId);
   }
 
   async createNote(notebookId: string, title = 'New Note', content = ''): Promise<{ noteId: string }> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.CREATE_NOTE,
-      [notebookId, '', [1], null, 'New Note'],
-      `/notebook/${notebookId}`,
-    );
-    const envelopes = parseEnvelopes(raw);
-    const first = envelopes[0];
-    let noteId = '';
-    if (Array.isArray(first) && Array.isArray(first[0]) && typeof first[0][0] === 'string') {
-      noteId = first[0][0];
-    } else if (Array.isArray(first) && typeof first[0] === 'string') {
-      noteId = first[0];
-    }
-    // Google ignores title in CREATE_NOTE, so always update after creation
-    if (noteId && (title !== 'New Note' || content)) {
-      await this.updateNote(notebookId, noteId, content, title);
-    }
-    return { noteId };
+    return api.createNote(this.rpc, notebookId, title, content);
   }
 
   async updateNote(notebookId: string, noteId: string, content: string, title: string): Promise<void> {
-    await this.callBatchExecute(
-      NB_RPC.UPDATE_NOTE,
-      [notebookId, noteId, [[[content, title, [], 0]]]],
-      `/notebook/${notebookId}`,
-    );
+    return api.updateNote(this.rpc, notebookId, noteId, content, title);
   }
 
   async deleteNote(notebookId: string, noteId: string): Promise<void> {
-    await this.callBatchExecute(
-      NB_RPC.DELETE_NOTE,
-      [notebookId, null, [noteId]],
-      `/notebook/${notebookId}`,
-    );
+    return api.deleteNote(this.rpc, notebookId, noteId);
   }
 
-  // ── Sharing ──
-
   async getShareStatus(notebookId: string): Promise<unknown> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.GET_SHARE_STATUS,
-      [notebookId, [...PLATFORM_WEB]],
-      `/notebook/${notebookId}`,
-    );
-    return parseEnvelopes(raw)[0] ?? null;
+    return api.getShareStatus(this.rpc, notebookId);
   }
 
   async shareNotebook(notebookId: string, isPublic: boolean): Promise<void> {
-    const access = isPublic ? 1 : 0;
-    await this.callBatchExecute(
-      NB_RPC.SHARE_NOTEBOOK,
-      [[[notebookId, null, [access], [access, '']]], 1, null, [...PLATFORM_WEB]],
-      `/notebook/${notebookId}`,
-    );
+    return api.shareNotebook(this.rpc, notebookId, isPublic);
   }
 
   async shareNotebookWithUser(
@@ -703,68 +427,23 @@ export class NotebookClient {
     permission: 'editor' | 'viewer' = 'viewer',
     options?: { notify?: boolean; message?: string },
   ): Promise<void> {
-    // Permission: 2=editor, 3=viewer
-    const permCode = permission === 'editor' ? 2 : 3;
-    const notify = options?.notify !== false ? 1 : 0;
-    const msg = options?.message ?? '';
-    const msgFlag = msg ? 0 : 1;
-    await this.callBatchExecute(
-      NB_RPC.SHARE_NOTEBOOK,
-      [[[notebookId, [[email, null, permCode]], null, [msgFlag, msg]]], notify, null, [...PLATFORM_WEB]],
-      `/notebook/${notebookId}`,
-    );
+    return api.shareNotebookWithUser(this.rpc, notebookId, email, permission, options);
   }
 
-  // ── Settings ──
-
   async getOutputLanguage(): Promise<string | null> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.GET_ACCOUNT_INFO,
-      [null, [1, null, null, null, null, null, null, null, null, null, [1]]],
-      '/',
-    );
-    const envelopes = parseEnvelopes(raw);
-    const result = envelopes[0];
-    // Path: result[0][2][4][0]
-    if (!Array.isArray(result)) return null;
-    const outer = Array.isArray(result[0]) ? result[0] as unknown[] : null;
-    if (!outer) return null;
-    const settings = Array.isArray(outer[2]) ? outer[2] as unknown[] : null;
-    if (!settings) return null;
-    const langArr = Array.isArray(settings[4]) ? settings[4] as unknown[] : null;
-    return langArr && typeof langArr[0] === 'string' ? langArr[0] : null;
+    return api.getOutputLanguage(this.rpc);
   }
 
   async setOutputLanguage(language: string): Promise<void> {
-    await this.callBatchExecute(
-      NB_RPC.SET_USER_SETTINGS,
-      [[[null, [[null, null, null, null, [language]]]]]],
-      '/',
-    );
+    return api.setOutputLanguage(this.rpc, language);
   }
 
-  // ── Artifact extras ──
-
   async renameArtifact(artifactId: string, newTitle: string): Promise<void> {
-    await this.callBatchExecute(NB_RPC.RENAME_ARTIFACT, [artifactId, newTitle]);
+    return api.renameArtifact(this.rpc, artifactId, newTitle);
   }
 
   async getInteractiveHtml(artifactId: string): Promise<string> {
-    const raw = await this.callBatchExecute(NB_RPC.GET_INTERACTIVE_HTML, [artifactId]);
-    const envelopes = parseEnvelopes(raw);
-    // Response may be: HTML string (ready), or artifact metadata array (still rendering).
-    const first = envelopes[0];
-    if (typeof first === 'string') return first;
-    if (Array.isArray(first)) {
-      // Check first-level and second-level for HTML string
-      if (typeof first[0] === 'string') return first[0];
-      // Artifact metadata array — HTML not ready yet; walk the tree for long strings that look like HTML
-      const flat = Array.isArray(first[0]) ? first[0] as unknown[] : first;
-      for (const el of flat) {
-        if (typeof el === 'string' && el.length > 200 && el.includes('<')) return el;
-      }
-    }
-    return '';
+    return api.getInteractiveHtml(this.rpc, artifactId);
   }
 
   async generateArtifact(
@@ -773,125 +452,41 @@ export class NotebookClient {
     sourceIds: string[],
     options?: ArtifactGenerateOptions | LegacyArtifactOptions,
   ): Promise<{ artifactId: string; title: string }> {
-    const sidsTriple = sourceIds.map((id) => [[id]]);
-    const sidsDouble = sourceIds.map((id) => [id]);
     const sessionLang = this.transport!.getSession().language ?? 'en';
-
-    let innerPayload: unknown[];
-
-    if (options && 'type' in options) {
-      // New discriminated union — inject session language as default
-      const opts = { ...options } as ArtifactGenerateOptions & { language?: string };
-      if (!opts.language) opts.language = sessionLang;
-      innerPayload = buildArtifactPayload(sidsTriple, sidsDouble, opts);
-    } else {
-      // Legacy format — backward compat (audio only)
-      const legacy = options as LegacyArtifactOptions | undefined;
-      innerPayload = buildArtifactPayload(sidsTriple, sidsDouble, {
-        type: 'audio',
-        instructions: legacy?.customPrompt ?? undefined,
-        language: legacy?.language ?? sessionLang,
-      });
-    }
-
-    const raw = await this.callBatchExecute(
-      NB_RPC.GENERATE_ARTIFACT,
-      [[...DEFAULT_USER_CONFIG], notebookId, innerPayload],
-      `/notebook/${notebookId}`,
-    );
-    return parseGenerateArtifact(raw);
+    return api.generateArtifact(this.rpc, notebookId, _type, sourceIds, sessionLang, options);
   }
 
   async getArtifacts(notebookId: string): Promise<ArtifactInfo[]> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.GET_ARTIFACTS_FILTERED,
-      [
-        [...DEFAULT_USER_CONFIG],
-        notebookId,
-        'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"',
-      ],
-      `/notebook/${notebookId}`,
-    );
-    return parseArtifacts(raw);
+    return api.getArtifacts(this.rpc, notebookId);
   }
 
   async deleteArtifact(artifactId: string): Promise<void> {
-    await this.callBatchExecute(NB_RPC.DELETE_ARTIFACT, [[...DEFAULT_USER_CONFIG], artifactId]);
+    return api.deleteArtifact(this.rpc, artifactId);
   }
 
-  /**
-   * Poll POLL_RESEARCH (e3bVqc) until research results are ready.
-   * Status codes: 1=in_progress, 2=completed (fast), 6=completed (deep).
-   */
+  async createWebSearch(notebookId: string, query: string, mode: 'fast' | 'deep' = 'fast'): Promise<{ researchId: string; artifactId?: string }> {
+    return api.createWebSearch(this.rpc, notebookId, query, mode);
+  }
+
   async pollResearchResults(notebookId: string, timeoutMs = 120_000): Promise<{ results: ResearchResult[]; report?: string }> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      const raw = await this.callBatchExecute(
-        NB_RPC.POLL_RESEARCH,
-        [null, null, notebookId],
-        `/notebook/${notebookId}`,
-      );
-      const parsed = parseResearchResults(raw);
-      if (parsed.status >= 2) {
-        console.error(`NotebookLM: Research completed — ${parsed.results.length} sources${parsed.report ? ' + report' : ''}`);
-        return { results: parsed.results, report: parsed.report };
-      }
-      await humanSleep(5000);
-    }
-    console.error('NotebookLM: Research poll timed out');
-    return { results: [] };
+    return api.pollResearchResults(this.rpc, notebookId, timeoutMs);
   }
 
-  /**
-   * Import research results as sources into a notebook.
-   * RPC: LBwxtb (IMPORT_RESEARCH)
-   *
-   * Source entry types:
-   *   URL:    [null, null, [url, title], null, ..., 2]
-   *   Report: [null, [title, markdown], null, 3, ..., 3]
-   */
   async importResearch(
     notebookId: string,
     researchId: string,
     results: ResearchResult[],
     report?: string,
   ): Promise<void> {
-    const sources: unknown[][] = [];
-
-    // Add deep research report as a text source if present
-    if (report) {
-      const reportTitle = 'Deep Research Report';
-      sources.push([null, [reportTitle, report], null, 3, null, null, null, null, null, null, 3]);
-    }
-
-    // Add URL sources
-    for (const r of results) {
-      sources.push([null, null, [r.url, r.title], null, null, null, null, null, null, null, 2]);
-    }
-
-    if (sources.length === 0) return;
-
-    await this.callBatchExecute(
-      NB_RPC.IMPORT_RESEARCH,
-      [null, [1], researchId, notebookId, sources],
-      `/notebook/${notebookId}`,
-    );
-    console.error(`NotebookLM: Imported ${sources.length} research sources`);
+    return api.importResearch(this.rpc, notebookId, researchId, results, report);
   }
 
   async getStudioConfig(notebookId: string): Promise<StudioConfig> {
-    const raw = await this.callBatchExecute(
-      NB_RPC.GET_STUDIO_CONFIG,
-      [[...DEFAULT_USER_CONFIG], notebookId],
-      `/notebook/${notebookId}`,
-    );
-    return parseStudioConfig(raw);
+    return api.getStudioConfig(this.rpc, notebookId);
   }
 
-  /** Get account info (plan type, limits). RPC: GetOrCreateAccount */
   async getAccountInfo(): Promise<AccountInfo> {
-    const raw = await this.callBatchExecute(NB_RPC.GET_ACCOUNT_INFO, [[...DEFAULT_USER_CONFIG]], '/');
-    return parseQuota(raw);
+    return api.getAccountInfo(this.rpc);
   }
 
   /** @deprecated Use getAccountInfo() instead */
@@ -901,758 +496,78 @@ export class NotebookClient {
 
   async downloadAudio(downloadUrl: string, outputDir: string): Promise<string> {
     const page = this.getActivePage();
-    if (!page) {
-      // HTTP mode: download directly via undici
-      return this.downloadAudioHttp(downloadUrl, outputDir);
+    if (page) {
+      return downloadAudioBrowser(page, downloadUrl, outputDir);
     }
-
-    // Browser mode: use CDP download
-    const currentUrl = page.url();
-    if (!currentUrl.includes('notebooklm.google.com')) {
-      await page.goto(NB_URLS.DASHBOARD, { waitUntil: 'networkidle2', timeout: 30000 });
-    }
-
-    mkdirSync(outputDir, { recursive: true });
-
-    const cdp = await page.createCDPSession();
-    try {
-      await cdp.send('Browser.setDownloadBehavior', {
-        behavior: 'allowAndName',
-        downloadPath: outputDir,
-        eventsEnabled: true,
-      });
-
-      await page.evaluate((url: string) => {
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'audio.mp4';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-      }, downloadUrl);
-
-      const filePath = await new Promise<string>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error('Audio download timed out')), 120000);
-        cdp.on('Browser.downloadProgress', (event: { guid: string; state: string }) => {
-          if (event.state === 'completed') {
-            clearTimeout(timeout);
-            resolve(join(outputDir, event.guid));
-          } else if (event.state === 'canceled') {
-            clearTimeout(timeout);
-            reject(new Error('Audio download canceled'));
-          }
-        });
-      });
-
-      console.error(`NotebookLM: Audio downloaded to ${filePath}`);
-      return filePath;
-    } finally {
-      try { await cdp.detach(); } catch { /* ignore */ }
-    }
-  }
-
-  private async downloadFileHttp(
-    downloadUrl: string,
-    outputDir: string,
-    filename: string,
-  ): Promise<string> {
-    if (!this.transport) throw new SessionError('Not connected');
-
-    mkdirSync(outputDir, { recursive: true });
-
-    const session = this.transport.getSession();
-    const filePath = join(outputDir, filename);
-
-    // Google download URLs redirect across domains (lh3.googleusercontent.com →
-    // lh3.google.com → accounts.google.com). Cookies must be sent with correct
-    // domain matching. Use curl-impersonate with a Netscape cookie jar built from
-    // the session's cookieJar (which preserves per-cookie domain info from CDP).
-    const { readFile, unlink } = await import('node:fs/promises');
-    const { writeFileSync } = await import('node:fs');
-    const { execFile } = await import('node:child_process');
-    const { promisify } = await import('node:util');
-    const execFileAsync = promisify(execFile);
-
-    const { CurlTransport } = await import('./transport-curl.js');
-    const curlBin = await CurlTransport.findBinary();
-    if (!curlBin) {
-      throw new Error('Audio download requires curl-impersonate. Run: npm run setup');
-    }
-
-    // Build Netscape cookie jar with proper domain scoping
-    const cookieJarPath = join(outputDir, `.cookiejar_${Date.now()}`);
-    const lines = ['# Netscape HTTP Cookie File'];
-
-    if (session.cookieJar && session.cookieJar.length > 0) {
-      // Use domain-scoped cookies (from CDP or inferred)
-      for (const c of session.cookieJar) {
-        // Netscape cookie jar format:
-        // domain  domain_flag  path  secure  expires  name  value
-        // domain_flag=TRUE means tail-match (e.g. .google.com matches *.google.com)
-        // domain_flag=FALSE means exact host match
-        const isDotDomain = c.domain.startsWith('.');
-        const domain = isDotDomain ? c.domain : c.domain;
-        const domainFlag = isDotDomain ? 'TRUE' : 'FALSE';
-        const secure = c.secure ? 'TRUE' : 'FALSE';
-        const path = c.path ?? '/';
-        lines.push(`${domain}\t${domainFlag}\t${path}\t${secure}\t0\t${c.name}\t${c.value}`);
-      }
-    } else {
-      // Fallback: flat cookies string → .google.com only.
-      // Downloads from CDN domains require export-session for proper domain cookies.
-      for (const pair of session.cookies.split(';')) {
-        const eq = pair.indexOf('=');
-        if (eq > 0) {
-          const name = pair.slice(0, eq).trim();
-          const value = pair.slice(eq + 1).trim();
-          const secure = name.startsWith('__Secure') || name.startsWith('__Host') ? 'TRUE' : 'FALSE';
-          lines.push(`.google.com\tTRUE\t/\t${secure}\t0\t${name}\t${value}`);
-        }
-      }
-    }
-    writeFileSync(cookieJarPath, lines.join('\n'), 'utf-8');
-
-    const curlArgs = [
-      '-sSL',
-      '-o', filePath,
-      '-b', cookieJarPath,
-      '-c', cookieJarPath,
-      '-H', `User-Agent: ${session.userAgent}`,
-      '-H', 'Referer: https://notebooklm.google.com/',
-      '--max-redirs', '20',
-    ];
-    if (this.proxy) {
-      curlArgs.push('-x', this.proxy);
-    }
-    curlArgs.push(downloadUrl);
-
-    // Retry loop: CDN may return 404 briefly after artifact URL appears
-    const maxRetries = 6;
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        await execFileAsync(curlBin, curlArgs, { timeout: 120_000 });
-      } catch (err) {
-        await unlink(cookieJarPath).catch(() => {});
-        throw new Error(`Audio download failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-
-      // Verify we got actual media, not HTML (404 page or login page)
-      const content = await readFile(filePath);
-      const head = content.slice(0, 50).toString('utf-8');
-      if (!head.includes('<!doctype') && !head.includes('<html')) {
-        // Got real media
-        break;
-      }
-
-      // HTML response — CDN not ready yet or auth issue
-      await unlink(filePath).catch(() => {});
-      if (attempt < maxRetries) {
-        const delay = attempt * 10_000; // 10s, 20s, 30s, ...
-        console.error(`NotebookLM: CDN not ready (attempt ${attempt}/${maxRetries}), retrying in ${delay / 1000}s...`);
-        await new Promise(r => setTimeout(r, delay));
-      } else {
-        await unlink(cookieJarPath).catch(() => {});
-        throw new Error('Audio download returned HTML after retries — CDN may be unavailable or session expired. Re-run: npx notebooklm export-session');
-      }
-    }
-
-    await unlink(cookieJarPath).catch(() => {});
-
-    console.error(`NotebookLM: Downloaded to ${filePath}`);
-    return filePath;
-  }
-
-  private async downloadAudioHttp(downloadUrl: string, outputDir: string): Promise<string> {
-    return this.downloadFileHttp(downloadUrl, outputDir, `audio_${Date.now()}.mp4`);
+    const session = this.transport!.getSession();
+    return downloadFileHttp({ session, proxy: this.proxy }, downloadUrl, outputDir, `audio_${Date.now()}.mp4`);
   }
 
   async sendChat(notebookId: string, message: string, sourceIds: string[]): Promise<{ text: string; threadId: string }> {
-    const raw = await this.callChatStream(notebookId, message, sourceIds);
-    const result = parseChatStream(raw);
-
+    const result = await api.sendChat(
+      this.callChatStream.bind(this),
+      notebookId, message, sourceIds,
+    );
     if (result.threadId) this.chatThreadId = result.threadId;
     this.chatHistory.push([message, null, 1]);
     if (result.text) {
       this.chatHistory.push([result.text, null, 2]);
     }
-
-    return { text: result.text, threadId: result.threadId };
+    return result;
   }
 
   async deleteChatThread(threadId: string): Promise<void> {
-    await this.callBatchExecute(NB_RPC.DELETE_CHAT_THREAD, [[], threadId, null, 1]);
-  }
-
-  // ── High-level Workflow Methods ──
-
-  async runAudioOverview(
-    options: AudioOverviewOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<AudioOverviewResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-
-    onProgress?.({ status: 'configuring', message: 'Waiting for source processing...' });
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating audio overview...' });
-    const config = await this.getStudioConfig(notebookId);
-    const audioType = config.audioTypes.find(t => t.name.includes('Deep Dive')) ?? config.audioTypes[0];
-    if (!audioType) throw new Error('No audio types available from Studio config');
-    const { artifactId } = await this.generateArtifact(
-      notebookId,
-      audioType.id,
-      sourceIds,
-      {
-        type: 'audio',
-        language: options.language,
-        instructions: options.instructions ?? options.customPrompt,
-        format: options.format,
-        length: options.length,
-      },
-    );
-
-    onProgress?.({ status: 'generating', message: 'Waiting for audio generation...' });
-    const artifact = await this.pollArtifactReady(notebookId, artifactId, 1_800_000);
-
-    onProgress?.({ status: 'downloading', message: 'Downloading audio...' });
-    const audioPath = await this.downloadAudio(artifact.downloadUrl!, options.outputDir);
-
-    onProgress?.({ status: 'completed', message: 'Audio overview complete!' });
-    return { audioPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
-  }
-
-  async runMindMap(
-    options: MindMapOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<MindMapResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating mind map (via page)...' });
-    const page = this.getActivePage();
-    if (page) {
-      await page.goto(`${NB_URLS.BASE}/notebook/${notebookId}`, { waitUntil: 'networkidle2', timeout: 60000 });
-      await humanSleep(5000);
-    }
-
-    mkdirSync(options.outputDir, { recursive: true });
-    const imagePath = join(options.outputDir, `mindmap_${Date.now()}.png`);
-    if (page) {
-      await page.screenshot({ path: imagePath, fullPage: true });
-    }
-
-    onProgress?.({ status: 'completed', message: 'Mind map complete!' });
-    return { imagePath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
-  }
-
-  async runFlashcards(
-    options: FlashcardsOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<FlashcardsResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating flashcards...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
-      type: 'flashcards',
-      instructions: options.instructions,
-      quantity: options.quantity,
-      difficulty: options.difficulty,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for flashcards...' });
-    await this.pollArtifactReady(notebookId, artifactId, 300_000);
-
-    onProgress?.({ status: 'downloading', message: 'Saving flashcards...' });
-    const htmlPath = await this.saveQuizHtml(artifactId, options.outputDir, 'flashcards');
-
-    onProgress?.({ status: 'completed', message: 'Flashcards generated!' });
-    return { htmlPath, cards: [], notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
-  }
-
-  async runAnalyze(
-    options: AnalyzeOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<AnalyzeResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Analyzing...' });
-    const { text } = await this.sendChat(notebookId, options.question, sourceIds);
-
-    onProgress?.({ status: 'completed', message: 'Analysis complete!' });
-    return { answer: text, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+    return api.deleteChatThread(this.rpc, threadId);
   }
 
   async chat(options: ChatOptions): Promise<ChatResult> {
     this.ensureConnected();
     if (!this.activeNotebookId) throw new Error('No active notebook. Create or open one first.');
-
     const detail = await this.getNotebookDetail(this.activeNotebookId);
     const sourceIds = detail.sources.map((s) => s.id);
-
     const { text } = await this.sendChat(this.activeNotebookId, options.message, sourceIds);
     return { response: text };
   }
 
-  async runReport(
-    options: ReportOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<ReportResult> {
-    this.ensureConnected();
+  // ── High-level Workflow Methods (delegated to workflows.ts) ──
 
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating report...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.REPORT, sourceIds, {
-      type: 'report',
-      template: options.template,
-      instructions: options.instructions,
-      language: options.language,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for report...' });
-    await this.pollArtifactReady(notebookId, artifactId, 300_000);
-
-    onProgress?.({ status: 'downloading', message: 'Saving report...' });
-    const markdownPath = await this.saveReport(artifactId, options.outputDir);
-
-    onProgress?.({ status: 'completed', message: 'Report complete!' });
-    return { markdownPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+  async runAudioOverview(options: AudioOverviewOptions, onProgress?: (p: WorkflowProgress) => void): Promise<AudioOverviewResult> {
+    return _runAudioOverview(this, options, onProgress);
   }
 
-  async runVideo(
-    options: VideoOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<VideoResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating video...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.VIDEO, sourceIds, {
-      type: 'video',
-      format: options.format,
-      style: options.style,
-      instructions: options.instructions,
-      language: options.language,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for video generation...' });
-    const artifact = await this.pollArtifactReady(notebookId, artifactId, 1_800_000);
-    const videoUrl = artifact.streamUrl ?? artifact.hlsUrl ?? artifact.downloadUrl ?? '';
-
-    onProgress?.({ status: 'completed', message: 'Video complete!' });
-    return { videoUrl, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+  async runMindMap(options: MindMapOptions, onProgress?: (p: WorkflowProgress) => void): Promise<MindMapResult> {
+    return _runMindMap(this, options, onProgress);
   }
 
-  async runQuiz(
-    options: QuizOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<QuizResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating quiz...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
-      type: 'quiz',
-      instructions: options.instructions,
-      quantity: options.quantity,
-      difficulty: options.difficulty,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for quiz...' });
-    await this.pollArtifactReady(notebookId, artifactId, 300_000);
-
-    onProgress?.({ status: 'downloading', message: 'Saving quiz...' });
-    const htmlPath = await this.saveQuizHtml(artifactId, options.outputDir, 'quiz');
-
-    onProgress?.({ status: 'completed', message: 'Quiz complete!' });
-    return { htmlPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+  async runFlashcards(options: FlashcardsOptions, onProgress?: (p: WorkflowProgress) => void): Promise<FlashcardsResult> {
+    return _runFlashcards(this, options, onProgress);
   }
 
-  async runInfographic(
-    options: InfographicOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<InfographicResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating infographic...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.INFOGRAPHIC, sourceIds, {
-      type: 'infographic',
-      instructions: options.instructions,
-      language: options.language,
-      orientation: options.orientation,
-      detail: options.detail,
-      style: options.style,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for infographic...' });
-    await this.pollArtifactReady(notebookId, artifactId, 300_000);
-
-    onProgress?.({ status: 'downloading', message: 'Saving infographic...' });
-    const imagePath = await this.saveInfographic(artifactId, options.outputDir);
-
-    onProgress?.({ status: 'completed', message: 'Infographic complete!' });
-    return { imagePath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+  async runAnalyze(options: AnalyzeOptions, onProgress?: (p: WorkflowProgress) => void): Promise<AnalyzeResult> {
+    return _runAnalyze(this, options, onProgress);
   }
 
-  async runSlideDeck(
-    options: SlideDeckOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<SlideDeckResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating slide deck...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.SLIDE_DECK, sourceIds, {
-      type: 'slide_deck',
-      instructions: options.instructions,
-      language: options.language,
-      format: options.format,
-      length: options.length,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for slides...' });
-    await this.pollArtifactReady(notebookId, artifactId, 300_000);
-
-    onProgress?.({ status: 'downloading', message: 'Downloading slides...' });
-    const { pptxPath, pdfPath } = await this.saveSlideDeck(artifactId, options.outputDir);
-
-    onProgress?.({ status: 'completed', message: 'Slide deck complete!' });
-    return { pptxPath, pdfPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+  async runReport(options: ReportOptions, onProgress?: (p: WorkflowProgress) => void): Promise<ReportResult> {
+    return _runReport(this, options, onProgress);
   }
 
-  async runDataTable(
-    options: DataTableOptions,
-    onProgress?: (p: WorkflowProgress) => void,
-  ): Promise<DataTableResult> {
-    this.ensureConnected();
-
-    onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
-    const { notebookId } = await this.createNotebook();
-
-    onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
-    const sourceIds = await this.addSourceFromInput(notebookId, options.source);
-    await this.pollSourcesReady(notebookId, 120_000);
-
-    onProgress?.({ status: 'generating', message: 'Generating data table...' });
-    const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.DATA_TABLE, sourceIds, {
-      type: 'data_table',
-      instructions: options.instructions,
-      language: options.language,
-    });
-
-    onProgress?.({ status: 'generating', message: 'Waiting for data table...' });
-    await this.pollArtifactReady(notebookId, artifactId, 300_000);
-
-    onProgress?.({ status: 'downloading', message: 'Saving data table...' });
-    const csvPath = await this.saveDataTable(artifactId, options.outputDir);
-
-    onProgress?.({ status: 'completed', message: 'Data table complete!' });
-    return { csvPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+  async runVideo(options: VideoOptions, onProgress?: (p: WorkflowProgress) => void): Promise<VideoResult> {
+    return _runVideo(this, options, onProgress);
   }
 
-  // ── Private Helpers ──
-
-  private async addSourceFromInput(notebookId: string, source: SourceInput): Promise<string[]> {
-    switch (source.type) {
-      case 'url': {
-        const { sourceId } = await this.addUrlSource(notebookId, source.url!);
-        return [sourceId];
-      }
-      case 'text': {
-        const { sourceId } = await this.addTextSource(notebookId, 'Pasted Text', source.text!);
-        return [sourceId];
-      }
-      case 'file': {
-        const { sourceId } = await this.addFileSource(notebookId, source.filePath!);
-        return [sourceId];
-      }
-      case 'research': {
-        const mode = source.researchMode ?? 'fast';
-        // Research requires at least one source in the notebook as seed
-        await this.addTextSource(notebookId, 'Research Topic', source.topic!);
-        const { researchId } = await this.createWebSearch(notebookId, source.topic!, mode);
-
-        // Both fast and deep use the same poll→import flow.
-        // Status codes differ: fast=2, deep=6, but parseResearchResults normalizes both to 2.
-        const timeoutMs = mode === 'deep' ? 1_200_000 : 120_000;
-        const { results, report } = await this.pollResearchResults(notebookId, timeoutMs);
-
-        if ((results.length > 0 || report) && researchId) {
-          await this.importResearch(notebookId, researchId, results, report);
-        }
-
-        // Wait for all imported sources to be processed
-        await this.pollSourcesReady(notebookId, 120_000);
-
-        const detail = await this.getNotebookDetail(notebookId);
-        return detail.sources.map((s) => s.id);
-      }
-    }
+  async runQuiz(options: QuizOptions, onProgress?: (p: WorkflowProgress) => void): Promise<QuizResult> {
+    return _runQuiz(this, options, onProgress);
   }
 
-  private async pollSourcesReady(notebookId: string, timeoutMs: number): Promise<void> {
-    const start = Date.now();
-    let pollCount = 0;
-    while (Date.now() - start < timeoutMs) {
-      const detail = await this.getNotebookDetail(notebookId);
-      const allReady = detail.sources.length > 0 && detail.sources.every((s) => s.wordCount !== undefined && s.wordCount > 0);
-      if (allReady) return;
-      pollCount++;
-      const delay = Math.min(3000 + pollCount * 1500, 15000);
-      await humanSleep(delay);
-    }
-    console.error('NotebookLM: Source processing may not have completed within timeout');
+  async runInfographic(options: InfographicOptions, onProgress?: (p: WorkflowProgress) => void): Promise<InfographicResult> {
+    return _runInfographic(this, options, onProgress);
   }
 
-  private async pollArtifactReady(notebookId: string, artifactId: string, timeoutMs: number): Promise<ArtifactInfo> {
-    const start = Date.now();
-    let pollCount = 0;
-
-    while (Date.now() - start < timeoutMs) {
-      const artifacts = await this.getArtifacts(notebookId);
-      const artifact = artifacts.find((a) => a.id === artifactId);
-      if (artifact) {
-        // Audio/Video: need a media URL
-        const isMedia = artifact.type === ARTIFACT_TYPE.AUDIO || artifact.type === ARTIFACT_TYPE.VIDEO;
-        if (isMedia) {
-          if (artifact.downloadUrl || artifact.streamUrl || artifact.hlsUrl) return artifact;
-        } else {
-          // HTML-based artifacts are ready as soon as they appear
-          return artifact;
-        }
-      }
-
-      pollCount++;
-      const baseDelay = Math.min(5000 + pollCount * 2500, 30000);
-      await humanSleep(baseDelay);
-    }
-    throw new Error('Artifact generation timed out');
+  async runSlideDeck(options: SlideDeckOptions, onProgress?: (p: WorkflowProgress) => void): Promise<SlideDeckResult> {
+    return _runSlideDeck(this, options, onProgress);
   }
 
-  /** Get raw artifact metadata from the GET_INTERACTIVE_HTML RPC. */
-  private async getArtifactMetadata(artifactId: string): Promise<unknown[]> {
-    const raw = await this.callBatchExecute(NB_RPC.GET_INTERACTIVE_HTML, [artifactId]);
-    const envelopes = parseEnvelopes(raw);
-    const first = envelopes[0];
-    if (Array.isArray(first) && Array.isArray(first[0])) return first[0] as unknown[];
-    if (Array.isArray(first)) return first as unknown[];
-    return [];
-  }
-
-  /** Poll artifact metadata until a condition is met. */
-  private async pollArtifactMetadata(
-    artifactId: string,
-    isReady: (meta: unknown[]) => boolean,
-    maxAttempts = 16,
-  ): Promise<unknown[]> {
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const meta = await this.getArtifactMetadata(artifactId);
-      if (meta.length > 0 && isReady(meta)) return meta;
-      await humanSleep(5000 + attempt * 3000);
-    }
-    return this.getArtifactMetadata(artifactId);
-  }
-
-  /** Save quiz/flashcards HTML (getInteractiveHtml returns HTML with data-app-data). */
-  private async saveQuizHtml(artifactId: string, outputDir: string, prefix: string): Promise<string> {
-    let html = '';
-    for (let attempt = 0; attempt < 12; attempt++) {
-      html = await this.getInteractiveHtml(artifactId);
-      if (html.length > 0) break;
-      await humanSleep(5000 + attempt * 2500);
-    }
-    mkdirSync(outputDir, { recursive: true });
-    const filePath = join(outputDir, `${prefix}_${Date.now()}.html`);
-    writeFileSync(filePath, html, 'utf-8');
-    return filePath;
-  }
-
-  /** Save slides — poll metadata[16] for PPTX/PDF URLs, then download. */
-  private async saveSlideDeck(
-    artifactId: string,
-    outputDir: string,
-  ): Promise<{ pptxPath: string; pdfPath?: string }> {
-    // Slides rendering takes 2-5 minutes — use more attempts with longer intervals
-    const meta = await this.pollArtifactMetadata(artifactId, (m) => {
-      const cfg = m[16];
-      return Array.isArray(cfg) && cfg.length >= 4 && typeof cfg[3] === 'string';
-    }, 40);
-
-    const cfg = meta[16] as unknown[];
-    if (!Array.isArray(cfg) || cfg.length < 4) {
-      throw new Error('Slide deck metadata not ready — PDF/PPTX URLs not found');
-    }
-
-    // cfg structure: [config, title, slides[], pdfUrl, pptxUrl]
-    const pdfUrl = typeof cfg[3] === 'string' ? cfg[3] : undefined;
-    const pptxUrl = typeof cfg[4] === 'string' ? cfg[4] : undefined;
-
-    const url = pptxUrl ?? pdfUrl;
-    if (!url) throw new Error('Slide deck: no download URL found in metadata');
-
-    const ext = pptxUrl ? 'pptx' : 'pdf';
-    const pptxPath = await this.downloadFileHttp(url, outputDir, `slides_${Date.now()}.${ext}`);
-
-    let pdfPath: string | undefined;
-    if (pptxUrl && pdfUrl) {
-      pdfPath = await this.downloadFileHttp(pdfUrl, outputDir, `slides_${Date.now()}.pdf`);
-    }
-
-    return { pptxPath, pdfPath };
-  }
-
-  /** Save report — poll metadata[7][0] for rendered markdown. */
-  private async saveReport(artifactId: string, outputDir: string): Promise<string> {
-    const meta = await this.pollArtifactMetadata(artifactId, (m) => {
-      const section = m[7];
-      // Before rendering: [7] = [null, [config...]]. After: [7] = ["# Markdown...", ...]
-      return Array.isArray(section) && typeof section[0] === 'string' && section[0].length > 100;
-    }, 30);
-
-    const section = meta[7] as unknown[];
-    const markdown = typeof section?.[0] === 'string' ? section[0] : undefined;
-    if (!markdown) {
-      throw new Error('Report markdown not found in metadata');
-    }
-
-    mkdirSync(outputDir, { recursive: true });
-    const filePath = join(outputDir, `report_${Date.now()}.md`);
-    writeFileSync(filePath, markdown, 'utf-8');
-    return filePath;
-  }
-
-  /** Save infographic — poll metadata for image URL, then download. */
-  private async saveInfographic(artifactId: string, outputDir: string): Promise<string> {
-    const meta = await this.pollArtifactMetadata(artifactId, (m) => {
-      const section = m[14];
-      if (!Array.isArray(section)) return false;
-      const json = JSON.stringify(section);
-      return json.includes('googleusercontent.com');
-    }, 30);
-
-    // Search for image URL in metadata[14]
-    const section = meta[14];
-    let imageUrl: string | undefined;
-    const json = JSON.stringify(section);
-    const urlMatch = json.match(/(https:\/\/lh3\.googleusercontent\.com\/[^"\\]+)/);
-    if (urlMatch) imageUrl = urlMatch[1];
-
-    if (!imageUrl) throw new Error('Infographic image URL not found in metadata');
-
-    return this.downloadFileHttp(imageUrl, outputDir, `infographic_${Date.now()}.png`);
-  }
-
-  /** Save data table — poll metadata for table data, save as CSV. */
-  private async saveDataTable(artifactId: string, outputDir: string): Promise<string> {
-    const meta = await this.pollArtifactMetadata(artifactId, (m) => {
-      // Data table content appears in metadata[18]
-      const section = m[18];
-      return Array.isArray(section) && section.length >= 2;
-    });
-
-    // Extract table structure from metadata
-    // Try to find structured data — the exact path varies, fallback to JSON dump
-    mkdirSync(outputDir, { recursive: true });
-
-    const section = meta[18];
-    let csvContent = '';
-
-    if (Array.isArray(section)) {
-      // Try to parse table cells from nested arrays
-      const rows = this.extractTableRows(section);
-      if (rows.length > 0) {
-        csvContent = rows.map(row =>
-          row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','),
-        ).join('\n');
-      }
-    }
-
-    if (!csvContent) {
-      // Fallback: save full metadata as JSON for manual inspection
-      const filePath = join(outputDir, `data_table_${Date.now()}.json`);
-      writeFileSync(filePath, JSON.stringify(section, null, 2), 'utf-8');
-      return filePath;
-    }
-
-    const filePath = join(outputDir, `data_table_${Date.now()}.csv`);
-    writeFileSync(filePath, csvContent, 'utf-8');
-    return filePath;
-  }
-
-  /** Try to extract rows from data table metadata. */
-  private extractTableRows(data: unknown[]): string[][] {
-    // Walk nested arrays to find tabular data (arrays of arrays of strings)
-    const rows: string[][] = [];
-    function walk(val: unknown): void {
-      if (!Array.isArray(val)) return;
-      // Check if this looks like a row of cells
-      if (val.length > 1 && val.every(cell => typeof cell === 'string' || typeof cell === 'number' || cell === null)) {
-        rows.push(val.map(cell => cell === null ? '' : String(cell)));
-        return;
-      }
-      for (const item of val) walk(item);
-    }
-    walk(data);
-    return rows;
-  }
-
-  private ensureConnected(): void {
-    if (!this.transport) throw new SessionError('NotebookLM client not connected');
+  async runDataTable(options: DataTableOptions, onProgress?: (p: WorkflowProgress) => void): Promise<DataTableResult> {
+    return _runDataTable(this, options, onProgress);
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -339,9 +339,7 @@ export class NotebookClient {
 
   // ── Bound RPC caller for api.ts functions ──
 
-  private get rpc() {
-    return this.callBatchExecute.bind(this);
-  }
+  private readonly rpc = this.callBatchExecute.bind(this);
 
   // ── Low-level API (delegated to api.ts) ──
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -446,12 +446,11 @@ export class NotebookClient {
 
   async generateArtifact(
     notebookId: string,
-    _type: number,
     sourceIds: string[],
     options?: ArtifactGenerateOptions | LegacyArtifactOptions,
   ): Promise<{ artifactId: string; title: string }> {
     const sessionLang = this.transport!.getSession().language ?? 'en';
-    return api.generateArtifact(this.rpc, notebookId, _type, sourceIds, sessionLang, options);
+    return api.generateArtifact(this.rpc, notebookId, sourceIds, sessionLang, options);
   }
 
   async getArtifacts(notebookId: string): Promise<ArtifactInfo[]> {

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,0 +1,378 @@
+/**
+ * Download & save logic — extracted from NotebookClient.
+ *
+ * All functions are standalone; they receive dependencies (session, proxy,
+ * RPC caller) as parameters so the module has no circular dependency on
+ * the client class.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Page } from 'puppeteer-core';
+import { NB_RPC, NB_URLS } from './rpc-ids.js';
+import { parseEnvelopes } from './boq-parser.js';
+import { humanSleep } from './utils/humanize.js';
+import type { NotebookRpcSession } from './types.js';
+
+// ── Types ──
+
+/** Minimal RPC caller — matches NotebookClient.callBatchExecute signature. */
+export type RpcCaller = (
+  rpcId: string,
+  payload: unknown[],
+  sourcePath?: string,
+) => Promise<string>;
+
+/** Dependencies for HTTP-based file downloads. */
+export interface DownloadDeps {
+  session: NotebookRpcSession;
+  proxy?: string;
+}
+
+/** Bound download function (URL → file path). */
+export type DownloadFn = (
+  downloadUrl: string,
+  outputDir: string,
+  filename: string,
+) => Promise<string>;
+
+// ── Core download functions ──
+
+/**
+ * Download a file via curl-impersonate with a Netscape cookie jar.
+ * Handles Google's cross-domain cookie requirements and CDN retry logic.
+ */
+export async function downloadFileHttp(
+  deps: DownloadDeps,
+  downloadUrl: string,
+  outputDir: string,
+  filename: string,
+): Promise<string> {
+  const { session, proxy } = deps;
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const filePath = join(outputDir, filename);
+
+  const { readFile, unlink } = await import('node:fs/promises');
+  const { writeFileSync: wfs } = await import('node:fs');
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFile);
+
+  const { CurlTransport } = await import('./transport-curl.js');
+  const curlBin = await CurlTransport.findBinary();
+  if (!curlBin) {
+    throw new Error('Audio download requires curl-impersonate. Run: npm run setup');
+  }
+
+  // Build Netscape cookie jar with proper domain scoping
+  const cookieJarPath = join(outputDir, `.cookiejar_${Date.now()}`);
+  const lines = ['# Netscape HTTP Cookie File'];
+
+  if (session.cookieJar && session.cookieJar.length > 0) {
+    for (const c of session.cookieJar) {
+      const isDotDomain = c.domain.startsWith('.');
+      const domain = isDotDomain ? c.domain : c.domain;
+      const domainFlag = isDotDomain ? 'TRUE' : 'FALSE';
+      const secure = c.secure ? 'TRUE' : 'FALSE';
+      const path = c.path ?? '/';
+      lines.push(`${domain}\t${domainFlag}\t${path}\t${secure}\t0\t${c.name}\t${c.value}`);
+    }
+  } else {
+    for (const pair of session.cookies.split(';')) {
+      const eq = pair.indexOf('=');
+      if (eq > 0) {
+        const name = pair.slice(0, eq).trim();
+        const value = pair.slice(eq + 1).trim();
+        const secure = name.startsWith('__Secure') || name.startsWith('__Host') ? 'TRUE' : 'FALSE';
+        lines.push(`.google.com\tTRUE\t/\t${secure}\t0\t${name}\t${value}`);
+      }
+    }
+  }
+  wfs(cookieJarPath, lines.join('\n'), 'utf-8');
+
+  const curlArgs = [
+    '-sSL',
+    '-o', filePath,
+    '-b', cookieJarPath,
+    '-c', cookieJarPath,
+    '-H', `User-Agent: ${session.userAgent}`,
+    '-H', 'Referer: https://notebooklm.google.com/',
+    '--max-redirs', '20',
+  ];
+  if (proxy) {
+    curlArgs.push('-x', proxy);
+  }
+  curlArgs.push(downloadUrl);
+
+  // Retry loop: CDN may return 404 briefly after artifact URL appears
+  const maxRetries = 6;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await execFileAsync(curlBin, curlArgs, { timeout: 120_000 });
+    } catch (err) {
+      await unlink(cookieJarPath).catch(() => {});
+      throw new Error(`Audio download failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    // Verify we got actual media, not HTML (404 page or login page)
+    const content = await readFile(filePath);
+    const head = content.slice(0, 50).toString('utf-8');
+    if (!head.includes('<!doctype') && !head.includes('<html')) {
+      break;
+    }
+
+    // HTML response — CDN not ready yet or auth issue
+    await unlink(filePath).catch(() => {});
+    if (attempt < maxRetries) {
+      const delay = attempt * 10_000;
+      console.error(`NotebookLM: CDN not ready (attempt ${attempt}/${maxRetries}), retrying in ${delay / 1000}s...`);
+      await new Promise(r => setTimeout(r, delay));
+    } else {
+      await unlink(cookieJarPath).catch(() => {});
+      throw new Error('Audio download returned HTML after retries — CDN may be unavailable or session expired. Re-run: npx notebooklm export-session');
+    }
+  }
+
+  await unlink(cookieJarPath).catch(() => {});
+
+  console.error(`NotebookLM: Downloaded to ${filePath}`);
+  return filePath;
+}
+
+/**
+ * Download audio via browser CDP (Puppeteer).
+ */
+export async function downloadAudioBrowser(
+  page: Page,
+  downloadUrl: string,
+  outputDir: string,
+): Promise<string> {
+  const currentUrl = page.url();
+  if (!currentUrl.includes('notebooklm.google.com')) {
+    await page.goto(NB_URLS.DASHBOARD, { waitUntil: 'networkidle2', timeout: 30000 });
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const cdp = await page.createCDPSession();
+  try {
+    await cdp.send('Browser.setDownloadBehavior', {
+      behavior: 'allowAndName',
+      downloadPath: outputDir,
+      eventsEnabled: true,
+    });
+
+    await page.evaluate((url: string) => {
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'audio.mp4';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    }, downloadUrl);
+
+    const filePath = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Audio download timed out')), 120000);
+      cdp.on('Browser.downloadProgress', (event: { guid: string; state: string }) => {
+        if (event.state === 'completed') {
+          clearTimeout(timeout);
+          resolve(join(outputDir, event.guid));
+        } else if (event.state === 'canceled') {
+          clearTimeout(timeout);
+          reject(new Error('Audio download canceled'));
+        }
+      });
+    });
+
+    console.error(`NotebookLM: Audio downloaded to ${filePath}`);
+    return filePath;
+  } finally {
+    try { await cdp.detach(); } catch { /* ignore */ }
+  }
+}
+
+// ── Artifact metadata helpers ──
+
+/** Get raw artifact metadata from the GET_INTERACTIVE_HTML RPC. */
+export async function getArtifactMetadata(
+  callRpc: RpcCaller,
+  artifactId: string,
+): Promise<unknown[]> {
+  const raw = await callRpc(NB_RPC.GET_INTERACTIVE_HTML, [artifactId]);
+  const envelopes = parseEnvelopes(raw);
+  const first = envelopes[0];
+  if (Array.isArray(first) && Array.isArray(first[0])) return first[0] as unknown[];
+  if (Array.isArray(first)) return first as unknown[];
+  return [];
+}
+
+/** Poll artifact metadata until a condition is met. */
+export async function pollArtifactMetadata(
+  callRpc: RpcCaller,
+  artifactId: string,
+  isReady: (meta: unknown[]) => boolean,
+  maxAttempts = 16,
+): Promise<unknown[]> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const meta = await getArtifactMetadata(callRpc, artifactId);
+    if (meta.length > 0 && isReady(meta)) return meta;
+    await humanSleep(5000 + attempt * 3000);
+  }
+  return getArtifactMetadata(callRpc, artifactId);
+}
+
+// ── Type-specific save functions ──
+
+/** Save quiz/flashcards HTML (getInteractiveHtml returns HTML with data-app-data). */
+export async function saveQuizHtml(
+  getInteractiveHtml: (artifactId: string) => Promise<string>,
+  artifactId: string,
+  outputDir: string,
+  prefix: string,
+): Promise<string> {
+  let html = '';
+  for (let attempt = 0; attempt < 12; attempt++) {
+    html = await getInteractiveHtml(artifactId);
+    if (html.length > 0) break;
+    await humanSleep(5000 + attempt * 2500);
+  }
+  mkdirSync(outputDir, { recursive: true });
+  const filePath = join(outputDir, `${prefix}_${Date.now()}.html`);
+  writeFileSync(filePath, html, 'utf-8');
+  return filePath;
+}
+
+/** Save report — poll metadata[7][0] for rendered markdown. */
+export async function saveReport(
+  callRpc: RpcCaller,
+  artifactId: string,
+  outputDir: string,
+): Promise<string> {
+  const meta = await pollArtifactMetadata(callRpc, artifactId, (m) => {
+    const section = m[7];
+    return Array.isArray(section) && typeof section[0] === 'string' && section[0].length > 100;
+  }, 30);
+
+  const section = meta[7] as unknown[];
+  const markdown = typeof section?.[0] === 'string' ? section[0] : undefined;
+  if (!markdown) {
+    throw new Error('Report markdown not found in metadata');
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  const filePath = join(outputDir, `report_${Date.now()}.md`);
+  writeFileSync(filePath, markdown, 'utf-8');
+  return filePath;
+}
+
+/** Save slides — poll metadata[16] for PPTX/PDF URLs, then download. */
+export async function saveSlideDeck(
+  callRpc: RpcCaller,
+  download: DownloadFn,
+  artifactId: string,
+  outputDir: string,
+): Promise<{ pptxPath: string; pdfPath?: string }> {
+  const meta = await pollArtifactMetadata(callRpc, artifactId, (m) => {
+    const cfg = m[16];
+    return Array.isArray(cfg) && cfg.length >= 4 && typeof cfg[3] === 'string';
+  }, 40);
+
+  const cfg = meta[16] as unknown[];
+  if (!Array.isArray(cfg) || cfg.length < 4) {
+    throw new Error('Slide deck metadata not ready — PDF/PPTX URLs not found');
+  }
+
+  const pdfUrl = typeof cfg[3] === 'string' ? cfg[3] : undefined;
+  const pptxUrl = typeof cfg[4] === 'string' ? cfg[4] : undefined;
+
+  const url = pptxUrl ?? pdfUrl;
+  if (!url) throw new Error('Slide deck: no download URL found in metadata');
+
+  const ext = pptxUrl ? 'pptx' : 'pdf';
+  const pptxPath = await download(url, outputDir, `slides_${Date.now()}.${ext}`);
+
+  let pdfPath: string | undefined;
+  if (pptxUrl && pdfUrl) {
+    pdfPath = await download(pdfUrl, outputDir, `slides_${Date.now()}.pdf`);
+  }
+
+  return { pptxPath, pdfPath };
+}
+
+/** Save infographic — poll metadata for image URL, then download. */
+export async function saveInfographic(
+  callRpc: RpcCaller,
+  download: DownloadFn,
+  artifactId: string,
+  outputDir: string,
+): Promise<string> {
+  const meta = await pollArtifactMetadata(callRpc, artifactId, (m) => {
+    const section = m[14];
+    if (!Array.isArray(section)) return false;
+    const json = JSON.stringify(section);
+    return json.includes('googleusercontent.com');
+  }, 30);
+
+  const section = meta[14];
+  let imageUrl: string | undefined;
+  const json = JSON.stringify(section);
+  const urlMatch = json.match(/(https:\/\/lh3\.googleusercontent\.com\/[^"\\]+)/);
+  if (urlMatch) imageUrl = urlMatch[1];
+
+  if (!imageUrl) throw new Error('Infographic image URL not found in metadata');
+
+  return download(imageUrl, outputDir, `infographic_${Date.now()}.png`);
+}
+
+/** Save data table — poll metadata for table data, save as CSV. */
+export async function saveDataTable(
+  callRpc: RpcCaller,
+  artifactId: string,
+  outputDir: string,
+): Promise<string> {
+  const meta = await pollArtifactMetadata(callRpc, artifactId, (m) => {
+    const section = m[18];
+    return Array.isArray(section) && section.length >= 2;
+  });
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const section = meta[18];
+  let csvContent = '';
+
+  if (Array.isArray(section)) {
+    const rows = extractTableRows(section);
+    if (rows.length > 0) {
+      csvContent = rows.map(row =>
+        row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','),
+      ).join('\n');
+    }
+  }
+
+  if (!csvContent) {
+    const filePath = join(outputDir, `data_table_${Date.now()}.json`);
+    writeFileSync(filePath, JSON.stringify(section, null, 2), 'utf-8');
+    return filePath;
+  }
+
+  const filePath = join(outputDir, `data_table_${Date.now()}.csv`);
+  writeFileSync(filePath, csvContent, 'utf-8');
+  return filePath;
+}
+
+/** Try to extract rows from data table metadata. */
+export function extractTableRows(data: unknown[]): string[][] {
+  const rows: string[][] = [];
+  function walk(val: unknown): void {
+    if (!Array.isArray(val)) return;
+    if (val.length > 1 && val.every(cell => typeof cell === 'string' || typeof cell === 'number' || cell === null)) {
+      rows.push(val.map(cell => cell === null ? '' : String(cell)));
+      return;
+    }
+    for (const item of val) walk(item);
+  }
+  walk(data);
+  return rows;
+}

--- a/src/download.ts
+++ b/src/download.ts
@@ -55,7 +55,6 @@ export async function downloadFileHttp(
   const filePath = join(outputDir, filename);
 
   const { readFile, unlink } = await import('node:fs/promises');
-  const { writeFileSync: wfs } = await import('node:fs');
   const { execFile } = await import('node:child_process');
   const { promisify } = await import('node:util');
   const execFileAsync = promisify(execFile);
@@ -90,7 +89,7 @@ export async function downloadFileHttp(
       }
     }
   }
-  wfs(cookieJarPath, lines.join('\n'), 'utf-8');
+  writeFileSync(cookieJarPath, lines.join('\n'), 'utf-8');
 
   const curlArgs = [
     '-sSL',

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -1,0 +1,473 @@
+/**
+ * High-level workflow orchestrations — extracted from NotebookClient.
+ *
+ * Each `run*` function takes a `NotebookClient` instance (import type only
+ * to avoid circular runtime dependency) and orchestrates a full workflow:
+ * create notebook → add source → generate artifact → download.
+ */
+
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { NB_URLS, ARTIFACT_TYPE } from './rpc-ids.js';
+import { humanSleep } from './utils/humanize.js';
+import {
+  downloadFileHttp,
+  saveQuizHtml,
+  saveReport,
+  saveSlideDeck,
+  saveInfographic,
+  saveDataTable,
+} from './download.js';
+import type { NotebookClient } from './client.js';
+import type {
+  SourceInput,
+  ArtifactInfo,
+  WorkflowProgress,
+  AudioOverviewOptions,
+  AudioOverviewResult,
+  MindMapOptions,
+  MindMapResult,
+  FlashcardsOptions,
+  FlashcardsResult,
+  AnalyzeOptions,
+  AnalyzeResult,
+  ReportOptions,
+  ReportResult,
+  VideoOptions,
+  VideoResult,
+  QuizOptions,
+  QuizResult,
+  InfographicOptions,
+  InfographicResult,
+  SlideDeckOptions,
+  SlideDeckResult,
+  DataTableOptions,
+  DataTableResult,
+} from './types.js';
+
+// ── Source helpers ──
+
+export async function addSourceFromInput(
+  client: NotebookClient,
+  notebookId: string,
+  source: SourceInput,
+): Promise<string[]> {
+  switch (source.type) {
+    case 'url': {
+      const { sourceId } = await client.addUrlSource(notebookId, source.url!);
+      return [sourceId];
+    }
+    case 'text': {
+      const { sourceId } = await client.addTextSource(notebookId, 'Pasted Text', source.text!);
+      return [sourceId];
+    }
+    case 'file': {
+      const { sourceId } = await client.addFileSource(notebookId, source.filePath!);
+      return [sourceId];
+    }
+    case 'research': {
+      const mode = source.researchMode ?? 'fast';
+      await client.addTextSource(notebookId, 'Research Topic', source.topic!);
+      const { researchId } = await client.createWebSearch(notebookId, source.topic!, mode);
+
+      const timeoutMs = mode === 'deep' ? 1_200_000 : 120_000;
+      const { results, report } = await client.pollResearchResults(notebookId, timeoutMs);
+
+      if ((results.length > 0 || report) && researchId) {
+        await client.importResearch(notebookId, researchId, results, report);
+      }
+
+      await pollSourcesReady(client, notebookId, 120_000);
+
+      const detail = await client.getNotebookDetail(notebookId);
+      return detail.sources.map((s) => s.id);
+    }
+  }
+}
+
+export async function pollSourcesReady(
+  client: NotebookClient,
+  notebookId: string,
+  timeoutMs: number,
+): Promise<void> {
+  const start = Date.now();
+  let pollCount = 0;
+  while (Date.now() - start < timeoutMs) {
+    const detail = await client.getNotebookDetail(notebookId);
+    const allReady = detail.sources.length > 0 && detail.sources.every((s) => s.wordCount !== undefined && s.wordCount > 0);
+    if (allReady) return;
+    pollCount++;
+    const delay = Math.min(3000 + pollCount * 1500, 15000);
+    await humanSleep(delay);
+  }
+  console.error('NotebookLM: Source processing may not have completed within timeout');
+}
+
+export async function pollArtifactReady(
+  client: NotebookClient,
+  notebookId: string,
+  artifactId: string,
+  timeoutMs: number,
+): Promise<ArtifactInfo> {
+  const start = Date.now();
+  let pollCount = 0;
+
+  while (Date.now() - start < timeoutMs) {
+    const artifacts = await client.getArtifacts(notebookId);
+    const artifact = artifacts.find((a) => a.id === artifactId);
+    if (artifact) {
+      const isMedia = artifact.type === ARTIFACT_TYPE.AUDIO || artifact.type === ARTIFACT_TYPE.VIDEO;
+      if (isMedia) {
+        if (artifact.downloadUrl || artifact.streamUrl || artifact.hlsUrl) return artifact;
+      } else {
+        return artifact;
+      }
+    }
+
+    pollCount++;
+    const baseDelay = Math.min(5000 + pollCount * 2500, 30000);
+    await humanSleep(baseDelay);
+  }
+  throw new Error('Artifact generation timed out');
+}
+
+// ── Bound download helper ──
+
+function boundDownloadFn(client: NotebookClient) {
+  const session = client.getRpcSession()!;
+  const proxy = client.getProxy();
+  return (url: string, outputDir: string, filename: string) =>
+    downloadFileHttp({ session, proxy }, url, outputDir, filename);
+}
+
+// ── Workflow functions ──
+
+export async function runAudioOverview(
+  client: NotebookClient,
+  options: AudioOverviewOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<AudioOverviewResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+
+  onProgress?.({ status: 'configuring', message: 'Waiting for source processing...' });
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating audio overview...' });
+  const config = await client.getStudioConfig(notebookId);
+  const audioType = config.audioTypes.find(t => t.name.includes('Deep Dive')) ?? config.audioTypes[0];
+  if (!audioType) throw new Error('No audio types available from Studio config');
+  const { artifactId } = await client.generateArtifact(
+    notebookId,
+    audioType.id,
+    sourceIds,
+    {
+      type: 'audio',
+      language: options.language,
+      instructions: options.instructions ?? options.customPrompt,
+      format: options.format,
+      length: options.length,
+    },
+  );
+
+  onProgress?.({ status: 'generating', message: 'Waiting for audio generation...' });
+  const artifact = await pollArtifactReady(client, notebookId, artifactId, 1_800_000);
+
+  onProgress?.({ status: 'downloading', message: 'Downloading audio...' });
+  const audioPath = await client.downloadAudio(artifact.downloadUrl!, options.outputDir);
+
+  onProgress?.({ status: 'completed', message: 'Audio overview complete!' });
+  return { audioPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runMindMap(
+  client: NotebookClient,
+  options: MindMapOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<MindMapResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating mind map (via page)...' });
+  const page = client.getActivePage();
+  if (page) {
+    await page.goto(`${NB_URLS.BASE}/notebook/${notebookId}`, { waitUntil: 'networkidle2', timeout: 60000 });
+    await humanSleep(5000);
+  }
+
+  mkdirSync(options.outputDir, { recursive: true });
+  const imagePath = join(options.outputDir, `mindmap_${Date.now()}.png`);
+  if (page) {
+    await page.screenshot({ path: imagePath, fullPage: true });
+  }
+
+  onProgress?.({ status: 'completed', message: 'Mind map complete!' });
+  return { imagePath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runFlashcards(
+  client: NotebookClient,
+  options: FlashcardsOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<FlashcardsResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating flashcards...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    type: 'flashcards',
+    instructions: options.instructions,
+    quantity: options.quantity,
+    difficulty: options.difficulty,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for flashcards...' });
+  await pollArtifactReady(client, notebookId, artifactId, 300_000);
+
+  onProgress?.({ status: 'downloading', message: 'Saving flashcards...' });
+  const htmlPath = await saveQuizHtml(
+    (id) => client.getInteractiveHtml(id),
+    artifactId, options.outputDir, 'flashcards',
+  );
+
+  onProgress?.({ status: 'completed', message: 'Flashcards generated!' });
+  return { htmlPath, cards: [], notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runAnalyze(
+  client: NotebookClient,
+  options: AnalyzeOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<AnalyzeResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Analyzing...' });
+  const { text } = await client.sendChat(notebookId, options.question, sourceIds);
+
+  onProgress?.({ status: 'completed', message: 'Analysis complete!' });
+  return { answer: text, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runReport(
+  client: NotebookClient,
+  options: ReportOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<ReportResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating report...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.REPORT, sourceIds, {
+    type: 'report',
+    template: options.template,
+    instructions: options.instructions,
+    language: options.language,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for report...' });
+  await pollArtifactReady(client, notebookId, artifactId, 300_000);
+
+  onProgress?.({ status: 'downloading', message: 'Saving report...' });
+  const callRpc = client.callBatchExecute.bind(client);
+  const markdownPath = await saveReport(callRpc, artifactId, options.outputDir);
+
+  onProgress?.({ status: 'completed', message: 'Report complete!' });
+  return { markdownPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runVideo(
+  client: NotebookClient,
+  options: VideoOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<VideoResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating video...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.VIDEO, sourceIds, {
+    type: 'video',
+    format: options.format,
+    style: options.style,
+    instructions: options.instructions,
+    language: options.language,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for video generation...' });
+  const artifact = await pollArtifactReady(client, notebookId, artifactId, 1_800_000);
+  const videoUrl = artifact.streamUrl ?? artifact.hlsUrl ?? artifact.downloadUrl ?? '';
+
+  onProgress?.({ status: 'completed', message: 'Video complete!' });
+  return { videoUrl, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runQuiz(
+  client: NotebookClient,
+  options: QuizOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<QuizResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating quiz...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    type: 'quiz',
+    instructions: options.instructions,
+    quantity: options.quantity,
+    difficulty: options.difficulty,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for quiz...' });
+  await pollArtifactReady(client, notebookId, artifactId, 300_000);
+
+  onProgress?.({ status: 'downloading', message: 'Saving quiz...' });
+  const htmlPath = await saveQuizHtml(
+    (id) => client.getInteractiveHtml(id),
+    artifactId, options.outputDir, 'quiz',
+  );
+
+  onProgress?.({ status: 'completed', message: 'Quiz complete!' });
+  return { htmlPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runInfographic(
+  client: NotebookClient,
+  options: InfographicOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<InfographicResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating infographic...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.INFOGRAPHIC, sourceIds, {
+    type: 'infographic',
+    instructions: options.instructions,
+    language: options.language,
+    orientation: options.orientation,
+    detail: options.detail,
+    style: options.style,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for infographic...' });
+  await pollArtifactReady(client, notebookId, artifactId, 300_000);
+
+  onProgress?.({ status: 'downloading', message: 'Saving infographic...' });
+  const callRpc = client.callBatchExecute.bind(client);
+  const imagePath = await saveInfographic(callRpc, boundDownloadFn(client), artifactId, options.outputDir);
+
+  onProgress?.({ status: 'completed', message: 'Infographic complete!' });
+  return { imagePath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runSlideDeck(
+  client: NotebookClient,
+  options: SlideDeckOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<SlideDeckResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating slide deck...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.SLIDE_DECK, sourceIds, {
+    type: 'slide_deck',
+    instructions: options.instructions,
+    language: options.language,
+    format: options.format,
+    length: options.length,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for slides...' });
+  await pollArtifactReady(client, notebookId, artifactId, 300_000);
+
+  onProgress?.({ status: 'downloading', message: 'Downloading slides...' });
+  const callRpc = client.callBatchExecute.bind(client);
+  const { pptxPath, pdfPath } = await saveSlideDeck(callRpc, boundDownloadFn(client), artifactId, options.outputDir);
+
+  onProgress?.({ status: 'completed', message: 'Slide deck complete!' });
+  return { pptxPath, pdfPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}
+
+export async function runDataTable(
+  client: NotebookClient,
+  options: DataTableOptions,
+  onProgress?: (p: WorkflowProgress) => void,
+): Promise<DataTableResult> {
+  client.ensureConnected();
+
+  onProgress?.({ status: 'creating_notebook', message: 'Creating notebook...' });
+  const { notebookId } = await client.createNotebook();
+
+  onProgress?.({ status: 'adding_source', message: `Adding source (${options.source.type})...` });
+  const sourceIds = await addSourceFromInput(client, notebookId, options.source);
+  await pollSourcesReady(client, notebookId, 120_000);
+
+  onProgress?.({ status: 'generating', message: 'Generating data table...' });
+  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.DATA_TABLE, sourceIds, {
+    type: 'data_table',
+    instructions: options.instructions,
+    language: options.language,
+  });
+
+  onProgress?.({ status: 'generating', message: 'Waiting for data table...' });
+  await pollArtifactReady(client, notebookId, artifactId, 300_000);
+
+  onProgress?.({ status: 'downloading', message: 'Saving data table...' });
+  const callRpc = client.callBatchExecute.bind(client);
+  const csvPath = await saveDataTable(callRpc, artifactId, options.outputDir);
+
+  onProgress?.({ status: 'completed', message: 'Data table complete!' });
+  return { csvPath, notebookUrl: `${NB_URLS.BASE}/notebook/${notebookId}` };
+}

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -164,7 +164,6 @@ export async function runAudioOverview(
   if (!audioType) throw new Error('No audio types available from Studio config');
   const { artifactId } = await client.generateArtifact(
     notebookId,
-    audioType.id,
     sourceIds,
     {
       type: 'audio',
@@ -231,7 +230,7 @@ export async function runFlashcards(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating flashcards...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'flashcards',
     instructions: options.instructions,
     quantity: options.quantity,
@@ -287,7 +286,7 @@ export async function runReport(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating report...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.REPORT, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'report',
     template: options.template,
     instructions: options.instructions,
@@ -320,7 +319,7 @@ export async function runVideo(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating video...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.VIDEO, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'video',
     format: options.format,
     style: options.style,
@@ -351,7 +350,7 @@ export async function runQuiz(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating quiz...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'quiz',
     instructions: options.instructions,
     quantity: options.quantity,
@@ -386,7 +385,7 @@ export async function runInfographic(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating infographic...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.INFOGRAPHIC, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'infographic',
     instructions: options.instructions,
     language: options.language,
@@ -421,7 +420,7 @@ export async function runSlideDeck(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating slide deck...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.SLIDE_DECK, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'slide_deck',
     instructions: options.instructions,
     language: options.language,
@@ -455,7 +454,7 @@ export async function runDataTable(
   await pollSourcesReady(client, notebookId, 120_000);
 
   onProgress?.({ status: 'generating', message: 'Generating data table...' });
-  const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.DATA_TABLE, sourceIds, {
+  const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
     type: 'data_table',
     instructions: options.instructions,
     language: options.language,

--- a/tests/e2e-artifacts.test.ts
+++ b/tests/e2e-artifacts.test.ts
@@ -12,7 +12,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { NotebookClient } from '../src/client.js';
 import { hasValidSession } from '../src/session-store.js';
 import { setHomeDir } from '../src/paths.js';
-import { ARTIFACT_TYPE } from '../src/rpc-ids.js';
 
 setHomeDir(process.env['NOTEBOOKLM_HOME'] ?? `${process.env['HOME']}/.notebooklm-work`);
 
@@ -88,7 +87,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a briefing doc report', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.REPORT, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'report',
       template: 'briefing_doc',
       instructions: 'Focus on machine learning concepts',
@@ -100,7 +99,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a study guide report', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.REPORT, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'report',
       template: 'study_guide',
     });
@@ -111,7 +110,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a custom report', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.REPORT, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'report',
       template: 'custom',
       instructions: 'Write a comparison table of supervised vs unsupervised learning',
@@ -125,7 +124,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a quiz', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'quiz',
       instructions: 'Focus on deep learning',
       difficulty: 'medium',
@@ -137,7 +136,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a quiz with quantity option', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'quiz',
       quantity: 'fewer',
       difficulty: 'easy',
@@ -149,7 +148,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a quiz with hard difficulty', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'quiz',
       difficulty: 'hard',
     });
@@ -162,7 +161,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate flashcards', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'flashcards',
       instructions: 'Key AI terminology',
     });
@@ -173,7 +172,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate flashcards with options', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'flashcards',
       quantity: 'standard',
       difficulty: 'medium',
@@ -185,7 +184,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate flashcards without instructions', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'flashcards',
     });
     console.log('Flashcards (no opts):', artifactId);
@@ -197,7 +196,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a slide deck', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.SLIDE_DECK, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'slide_deck',
       instructions: 'Make it visual and concise',
     });
@@ -208,7 +207,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate presenter slides', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.SLIDE_DECK, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'slide_deck',
       format: 'presenter',
       length: 'short',
@@ -220,7 +219,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate detailed slides', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.SLIDE_DECK, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'slide_deck',
       format: 'detailed',
     });
@@ -233,7 +232,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a data table', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId, title } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.DATA_TABLE, sourceIds, {
+    const { artifactId, title } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'data_table',
       instructions: 'Compare AI subfields by key characteristics',
     });
@@ -244,7 +243,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a data table in Chinese', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.DATA_TABLE, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'data_table',
       language: 'zh',
       instructions: '对比各种AI技术的优缺点',
@@ -256,7 +255,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate a data table without instructions', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.DATA_TABLE, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'data_table',
     });
     console.log('Data table (no opts):', artifactId);
@@ -268,11 +267,8 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate audio with legacy options (backward compat)', async () => {
     if (skipIfNoSession()) return;
-    const config = await client.getStudioConfig(notebookId);
-    const audioType = config.audioTypes.find(t => t.name.includes('Deep Dive')) ?? config.audioTypes[0];
-    expect(audioType).toBeDefined();
 
-    const { artifactId } = await client.generateArtifact(notebookId, audioType!.id, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       customPrompt: 'Explain like a podcast for beginners',
     });
     console.log('Audio (legacy):', artifactId);
@@ -282,7 +278,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate audio with new format options', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.AUDIO, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'audio',
       format: 'debate',
       length: 'short',
@@ -295,7 +291,7 @@ describe('E2E Artifact Generation', () => {
 
   it('should generate audio with brief format', async () => {
     if (skipIfNoSession()) return;
-    const { artifactId } = await client.generateArtifact(notebookId, ARTIFACT_TYPE.AUDIO, sourceIds, {
+    const { artifactId } = await client.generateArtifact(notebookId, sourceIds, {
       type: 'audio',
       format: 'brief',
     });

--- a/tests/e2e-http.test.ts
+++ b/tests/e2e-http.test.ts
@@ -226,15 +226,9 @@ describe('E2E HTTP Transport', () => {
 
   it('should generate an audio artifact', async () => {
     if (!hasSession || !testNotebookId || !testSourceId) return expect(true).toBe(true);
-    // Use dynamic studio config instead of hardcoded type ID
-    const config = await client.getStudioConfig(testNotebookId);
-    const deepDive = config.audioTypes.find(t => t.name.includes('Deep Dive'));
-    const audioType = deepDive ?? config.audioTypes[0];
-    expect(audioType).toBeDefined();
 
     const result = await client.generateArtifact(
       testNotebookId,
-      audioType!.id,
       [testSourceId],
     );
     expect(result.artifactId).toBeTruthy();


### PR DESCRIPTION
## Summary

- Split monolithic `client.ts` (1200+ lines) into focused modules: `api.ts`, `download.ts`, `workflows.ts`
- Cache bound RPC caller to avoid re-binding on every call
- Remove unused `_type: number` parameter from `generateArtifact` signature (closes #10) — the actual artifact type is determined by `options.type`

## Test plan

- [x] `npm run build` passes
- [x] 113 unit tests pass (`npx vitest run`)
- [ ] E2E tests with live session (`npx vitest run -c vitest.e2e.config.ts`)