### PR TITLE
fix: pass cookies via file instead of CLI args in curl transport

### DIFF
--- a/src/transport-curl.ts
+++ b/src/transport-curl.ts
@@ -6,6 +6,8 @@
  */
 
 import { execFile as execFileCb } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { platform } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -71,6 +73,13 @@ export class CurlTransport implements Transport {
       const body = new URLSearchParams(req.body).toString();
       const headers = this.buildHeaders();
 
+      // Write cookies to a temp file to avoid exceeding OS argument length limits.
+      // Google sessions carry many large cookies that easily blow past ARG_MAX
+      // when passed via -H "Cookie: ...".
+      const cookieFilePath = join(tmpdir(), `.nblm-curl-cookies-${process.pid}-${Date.now()}`);
+      const cookieFileContent = this.buildCookieFile();
+      writeFileSync(cookieFilePath, cookieFileContent, 'utf-8');
+
       const args: string[] = [
         '--impersonate', 'chrome136',
         url,
@@ -79,6 +88,7 @@ export class CurlTransport implements Transport {
         '-X', 'POST',
         '--data', body,
         '-w', '\n%{http_code}', // append status code
+        '-b', cookieFilePath,  // read cookies from file
       ];
 
       if (this.proxy) {
@@ -89,28 +99,32 @@ export class CurlTransport implements Transport {
         args.push('-H', `${key}: ${value}`);
       }
 
-      const { stdout, stderr } = await execFileAsync(this.binaryPath, args, {
-        timeout: 60_000,
-        maxBuffer: 10 * 1024 * 1024,
-      });
+      try {
+        const { stdout, stderr } = await execFileAsync(this.binaryPath, args, {
+          timeout: 60_000,
+          maxBuffer: 10 * 1024 * 1024,
+        });
 
-      if (stderr && stderr.includes('curl:')) {
-        throw new Error(`curl-impersonate error: ${stderr.trim()}`);
+        if (stderr && stderr.includes('curl:')) {
+          throw new Error(`curl-impersonate error: ${stderr.trim()}`);
+        }
+
+        // Response format: <body>\n<status_code>
+        const lastNewline = stdout.lastIndexOf('\n');
+        const responseBody = lastNewline > 0 ? stdout.slice(0, lastNewline) : stdout;
+        const statusCode = lastNewline > 0 ? parseInt(stdout.slice(lastNewline + 1).trim(), 10) : 200;
+
+        if (statusCode === 401 || statusCode === 400) {
+          throw new SessionError(`HTTP ${statusCode}`);
+        }
+        if (statusCode < 200 || statusCode >= 300) {
+          throw new Error(`HTTP ${statusCode}: ${responseBody.slice(0, 200)}`);
+        }
+
+        return responseBody;
+      } finally {
+        try { unlinkSync(cookieFilePath); } catch { /* ignore cleanup errors */ }
       }
-
-      // Response format: <body>\n<status_code>
-      const lastNewline = stdout.lastIndexOf('\n');
-      const responseBody = lastNewline > 0 ? stdout.slice(0, lastNewline) : stdout;
-      const statusCode = lastNewline > 0 ? parseInt(stdout.slice(lastNewline + 1).trim(), 10) : 200;
-
-      if (statusCode === 401 || statusCode === 400) {
-        throw new SessionError(`HTTP ${statusCode}`);
-      }
-      if (statusCode < 200 || statusCode >= 300) {
-        throw new Error(`HTTP ${statusCode}: ${responseBody.slice(0, 200)}`);
-      }
-
-      return responseBody;
     };
 
     try {
@@ -147,10 +161,10 @@ export class CurlTransport implements Transport {
 
   private buildHeaders(): Record<string, string> {
     const ua = this.session.userAgent || DEFAULT_USER_AGENT;
+    // Cookie is passed via -b <file> to avoid exceeding OS argument length limits
     return {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
       'User-Agent': ua,
-      'Cookie': this.session.cookies,
       'Origin': 'https://notebooklm.google.com',
       'Referer': 'https://notebooklm.google.com/',
       'Accept': '*/*',
@@ -163,6 +177,35 @@ export class CurlTransport implements Transport {
       'Sec-Fetch-Site': 'same-origin',
       'X-Same-Domain': '1',
     };
+  }
+
+  /** Build a Netscape-format cookie file from session cookies. */
+  private buildCookieFile(): string {
+    const lines = ['# Netscape HTTP Cookie File'];
+    const session = this.session;
+
+    if (session.cookieJar && session.cookieJar.length > 0) {
+      for (const c of session.cookieJar) {
+        const isDotDomain = c.domain.startsWith('.');
+        const domainFlag = isDotDomain ? 'TRUE' : 'FALSE';
+        const secure = c.secure ? 'TRUE' : 'FALSE';
+        const path = c.path ?? '/';
+        lines.push(`${c.domain}\t${domainFlag}\t${path}\t${secure}\t0\t${c.name}\t${c.value}`);
+      }
+    } else {
+      // Fallback: parse flat cookie string → scope to .google.com
+      for (const pair of session.cookies.split(';')) {
+        const eq = pair.indexOf('=');
+        if (eq > 0) {
+          const name = pair.slice(0, eq).trim();
+          const value = pair.slice(eq + 1).trim();
+          const secure = name.startsWith('__Secure') || name.startsWith('__Host') ? 'TRUE' : 'FALSE';
+          lines.push(`.google.com\tTRUE\t/\t${secure}\t0\t${name}\t${value}`);
+        }
+      }
+    }
+
+    return lines.join('\n');
   }
 
   // ── Static Detection ──

--- a/tests/transport-curl.test.ts
+++ b/tests/transport-curl.test.ts
@@ -2,11 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { NotebookRpcSession } from '../src/types.js';
 import type { TransportRequest } from '../src/transport.js';
 
-// Mock child_process before importing CurlTransport
+// Mock child_process and fs before importing CurlTransport
 const mockExecFile = vi.fn();
 vi.mock('node:child_process', () => ({
   execFile: mockExecFile,
 }));
+
+let lastWrittenCookieFile = '';
+let lastWrittenCookieContent = '';
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    writeFileSync: (path: string, content: string) => {
+      lastWrittenCookieFile = path;
+      lastWrittenCookieContent = content;
+    },
+    unlinkSync: () => {},
+  };
+});
 
 const { CurlTransport } = await import('../src/transport-curl.js');
 
@@ -79,7 +93,17 @@ describe('CurlTransport', () => {
     expect(capturedArgs).toContain('--compressed');
 
     const headerValues = capturedArgs.filter((_: string, i: number) => capturedArgs[i - 1] === '-H');
-    expect(headerValues.some((h: string) => h.includes('Cookie: SID=abc'))).toBe(true);
+    // Cookie should NOT be in -H args (passed via -b cookie file instead)
+    expect(headerValues.some((h: string) => h.includes('Cookie:'))).toBe(false);
+    // Cookie should be in -b file arg
+    expect(capturedArgs).toContain('-b');
+    const bIdx = capturedArgs.indexOf('-b');
+    expect(capturedArgs[bIdx + 1]).toContain('nblm-curl-cookies');
+    // Cookie content should be written to file in Netscape format
+    expect(lastWrittenCookieContent).toContain('# Netscape HTTP Cookie File');
+    expect(lastWrittenCookieContent).toContain('SID');
+    expect(lastWrittenCookieContent).toContain('abc');
+
     expect(headerValues.some((h: string) => h.includes('X-Same-Domain: 1'))).toBe(true);
     expect(headerValues.some((h: string) => h.includes('Sec-Fetch-Mode: cors'))).toBe(true);
     expect(headerValues.some((h: string) => h.includes('Origin: https://notebooklm.google.com'))).toBe(true);


### PR DESCRIPTION
## Summary

- 通过临时文件传递 cookies 给 curl，避免超出 OS 的 ARG_MAX 限制
- Google 会话 cookies 数量多且体积大，直接通过 `-H "Cookie: ..."` 传递容易超限
- 使用 Netscape 格式 cookie 文件，通过 `-b <file>` 参数传递

## Test plan

- [ ] 单元测试验证 cookies 通过 `-b` 文件传递而非 `-H` 头
- [ ] 验证 cookie 文件为 Netscape 格式
- [ ] 验证临时文件在请求完成后被清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)