### PR TITLE
feat: show Studio artifacts in detail command + fix quiz/infographic download

### DIFF
--- a/src/artifact-payloads.ts
+++ b/src/artifact-payloads.ts
@@ -165,12 +165,13 @@ export function buildQuizPayload(
   opts: QuizArtifactOptions,
 ): unknown[] {
   const instructions = opts.instructions ?? null;
+  const language = opts.language ?? null;
   const quantityCode = opts.quantity ? QUIZ_QUANTITY_CODE[opts.quantity] : null;
   const difficultyCode = opts.difficulty ? QUIZ_DIFFICULTY_CODE[opts.difficulty] : null;
 
   return [
     null, null, 4, sidsTriple, null, null, null, null, null,
-    [null, [2, null, instructions, null, null, null, null, [quantityCode, difficultyCode]]],
+    [null, [2, null, instructions, language, null, null, null, [quantityCode, difficultyCode]]],
   ];
 }
 
@@ -180,13 +181,14 @@ export function buildFlashcardsPayload(
   opts: FlashcardsArtifactOptions,
 ): unknown[] {
   const instructions = opts.instructions ?? null;
+  const language = opts.language ?? null;
   const quantityCode = opts.quantity ? QUIZ_QUANTITY_CODE[opts.quantity] : null;
   const difficultyCode = opts.difficulty ? QUIZ_DIFFICULTY_CODE[opts.difficulty] : null;
 
   // Flashcards: [difficulty, quantity] — reversed from quiz!
   return [
     null, null, 4, sidsTriple, null, null, null, null, null,
-    [null, [1, null, instructions, null, null, null, [difficultyCode, quantityCode]]],
+    [null, [1, null, instructions, language, null, null, [difficultyCode, quantityCode]]],
   ];
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -508,7 +508,7 @@ const ARTIFACT_TYPE_LABEL: Record<number, string> = {
 
 function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
+  const s = Math.floor(seconds % 60);
   return m > 0 ? `${m}m${s > 0 ? `${s}s` : ''}` : `${s}s`;
 }
 
@@ -521,7 +521,7 @@ addBrowserOptions(detailCmd)
     await withClient(opts, async (client) => {
       const [detail, artifacts] = await Promise.all([
         client.getNotebookDetail(notebookId),
-        client.getArtifacts(notebookId),
+        client.getArtifacts(notebookId).catch(() => []),
       ]);
       console.log(`Title: ${detail.title}`);
       console.log(`Sources (${detail.sources.length}):`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -324,6 +324,7 @@ const quizCmd = new Command('quiz')
 addBrowserOptions(addSourceOptions(quizCmd))
   .requiredOption('-o, --output <dir>', 'Output directory')
   .option('--instructions <text>', 'Custom instructions')
+  .option('-l, --language <lang>', 'Output language', 'en')
   .option('--quantity <q>', 'Quiz quantity: fewer | standard')
   .option('--difficulty <d>', 'Quiz difficulty: easy | medium | hard')
   .action(async (opts) => {
@@ -334,6 +335,7 @@ addBrowserOptions(addSourceOptions(quizCmd))
           source,
           outputDir: opts.output,
           instructions: opts.instructions,
+          language: opts.language,
           quantity: opts.quantity,
           difficulty: opts.difficulty,
         },
@@ -354,6 +356,7 @@ const flashcardsCmd = new Command('flashcards')
 addBrowserOptions(addSourceOptions(flashcardsCmd))
   .requiredOption('-o, --output <dir>', 'Output directory')
   .option('--instructions <text>', 'Custom instructions')
+  .option('-l, --language <lang>', 'Output language', 'en')
   .option('--quantity <q>', 'Flashcard quantity: fewer | standard')
   .option('--difficulty <d>', 'Flashcard difficulty: easy | medium | hard')
   .action(async (opts) => {
@@ -364,6 +367,7 @@ addBrowserOptions(addSourceOptions(flashcardsCmd))
           source,
           outputDir: opts.output,
           instructions: opts.instructions,
+          language: opts.language,
           quantity: opts.quantity,
           difficulty: opts.difficulty,
         },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { NotebookClient } from './client.js';
 import type { TransportMode } from './client.js';
 import { setHomeDir } from './paths.js';
 import type { SourceInput, WorkflowProgress } from './types.js';
+import { ARTIFACT_TYPE } from './rpc-ids.js';
 
 const program = new Command();
 
@@ -494,6 +495,23 @@ program.addCommand(listCmd);
 
 // ── Detail Command ──
 
+const ARTIFACT_TYPE_LABEL: Record<number, string> = {
+  [ARTIFACT_TYPE.AUDIO]: 'audio',
+  [ARTIFACT_TYPE.REPORT]: 'report',
+  [ARTIFACT_TYPE.VIDEO]: 'video',
+  [ARTIFACT_TYPE.QUIZ]: 'quiz',
+  [ARTIFACT_TYPE.MIND_MAP]: 'mind-map',
+  [ARTIFACT_TYPE.INFOGRAPHIC]: 'infographic',
+  [ARTIFACT_TYPE.SLIDE_DECK]: 'slides',
+  [ARTIFACT_TYPE.DATA_TABLE]: 'data-table',
+};
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m${s > 0 ? `${s}s` : ''}` : `${s}s`;
+}
+
 const detailCmd = new Command('detail')
   .description('Show notebook details')
   .argument('<notebook-id>', 'Notebook ID');
@@ -501,13 +519,24 @@ const detailCmd = new Command('detail')
 addBrowserOptions(detailCmd)
   .action(async (notebookId: string, opts) => {
     await withClient(opts, async (client) => {
-      const detail = await client.getNotebookDetail(notebookId);
+      const [detail, artifacts] = await Promise.all([
+        client.getNotebookDetail(notebookId),
+        client.getArtifacts(notebookId),
+      ]);
       console.log(`Title: ${detail.title}`);
       console.log(`Sources (${detail.sources.length}):`);
       for (const src of detail.sources) {
         const words = src.wordCount !== undefined ? ` [${src.wordCount} words]` : '';
         const url = src.url ? ` ${src.url}` : '';
         console.log(`  ${src.id}  ${src.title}${words}${url}`);
+      }
+      if (artifacts.length > 0) {
+        console.log(`Studio (${artifacts.length}):`);
+        for (const a of artifacts) {
+          const typeName = ARTIFACT_TYPE_LABEL[a.type] ?? `type:${a.type}`;
+          const duration = a.durationSeconds !== undefined ? ` [${formatDuration(a.durationSeconds)}]` : '';
+          console.log(`  ${a.id}  [${typeName}] ${a.title}${duration}`);
+        }
       }
     });
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -758,10 +758,12 @@ export class NotebookClient {
     if (Array.isArray(first)) {
       // Check first-level and second-level for HTML string
       if (typeof first[0] === 'string') return first[0];
-      // Artifact metadata array — HTML not ready yet; walk the tree for long strings that look like HTML
+      // Artifact metadata array — walk the tree for long strings that look like HTML.
+      // HTML may be a direct string element or wrapped in a single-element array (e.g. flat[9][0]).
       const flat = Array.isArray(first[0]) ? first[0] as unknown[] : first;
       for (const el of flat) {
         if (typeof el === 'string' && el.length > 200 && el.includes('<')) return el;
+        if (Array.isArray(el) && typeof el[0] === 'string' && el[0].length > 200 && el[0].includes('<')) return el[0];
       }
     }
     return '';

--- a/src/client.ts
+++ b/src/client.ts
@@ -1014,48 +1014,74 @@ export class NotebookClient {
     }
     writeFileSync(cookieJarPath, lines.join('\n'), 'utf-8');
 
-    const curlArgs = [
-      '-sSL',
-      '-o', filePath,
-      '-b', cookieJarPath,
-      '-c', cookieJarPath,
-      '-H', `User-Agent: ${session.userAgent}`,
-      '-H', 'Referer: https://notebooklm.google.com/',
-      '--max-redirs', '20',
+    const buildCurlArgs = (_bin: string, cookiePath: string): string[] => {
+      const args = [
+        '-sSL',
+        '-o', filePath,
+        '-b', cookiePath,
+        '-c', cookiePath,
+        '-H', `User-Agent: ${session.userAgent}`,
+        '-H', 'Referer: https://notebooklm.google.com/',
+        '--max-redirs', '20',
+      ];
+      if (this.proxy) args.push('-x', this.proxy);
+      args.push(downloadUrl);
+      return args;
+    };
+
+    // Try curl-impersonate first. Some CDN domains (lh3.google.com) reject its TLS
+    // fingerprint with error 56 — fall back to system curl which uses native TLS.
+    const systemCurl = 'curl';
+    const candidates: Array<{ bin: string; label: string }> = [
+      { bin: curlBin, label: 'curl-impersonate' },
+      { bin: systemCurl, label: 'system curl' },
     ];
-    if (this.proxy) {
-      curlArgs.push('-x', this.proxy);
-    }
-    curlArgs.push(downloadUrl);
 
     // Retry loop: CDN may return 404 briefly after artifact URL appears
     const maxRetries = 6;
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        await execFileAsync(curlBin, curlArgs, { timeout: 120_000 });
-      } catch (err) {
-        await unlink(cookieJarPath).catch(() => {});
-        throw new Error(`Audio download failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
+    let lastError = '';
+    outer: for (const { bin, label } of candidates) {
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          await execFileAsync(bin, buildCurlArgs(bin, cookieJarPath), { timeout: 120_000 });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          lastError = `${label}: ${msg}`;
+          // Transient network error (e.g. curl exit 56 connection reset) — retry
+          if (attempt < 3) {
+            const delay = attempt * 3_000;
+            console.error(`NotebookLM: Download error with ${label} (attempt ${attempt}), retrying in ${delay / 1000}s...`);
+            await new Promise(r => setTimeout(r, delay));
+            continue;
+          }
+          // Exhausted retries for this binary — try next candidate
+          console.error(`NotebookLM: ${label} failed, trying fallback...`);
+          continue outer;
+        }
 
-      // Verify we got actual media, not HTML (404 page or login page)
-      const content = await readFile(filePath);
-      const head = content.slice(0, 50).toString('utf-8');
-      if (!head.includes('<!doctype') && !head.includes('<html')) {
-        // Got real media
-        break;
-      }
+        // Verify we got actual media, not an HTML error page
+        const content = await readFile(filePath);
+        const head = content.slice(0, 50).toString('utf-8');
+        if (!head.includes('<!doctype') && !head.includes('<html')) {
+          break outer;
+        }
 
-      // HTML response — CDN not ready yet or auth issue
-      await unlink(filePath).catch(() => {});
-      if (attempt < maxRetries) {
-        const delay = attempt * 10_000; // 10s, 20s, 30s, ...
-        console.error(`NotebookLM: CDN not ready (attempt ${attempt}/${maxRetries}), retrying in ${delay / 1000}s...`);
-        await new Promise(r => setTimeout(r, delay));
-      } else {
-        await unlink(cookieJarPath).catch(() => {});
-        throw new Error('Audio download returned HTML after retries — CDN may be unavailable or session expired. Re-run: npx notebooklm export-session');
+        // HTML response — CDN not ready yet or auth issue
+        await unlink(filePath).catch(() => {});
+        if (attempt < maxRetries) {
+          const delay = attempt * 10_000;
+          console.error(`NotebookLM: CDN not ready (attempt ${attempt}/${maxRetries}), retrying in ${delay / 1000}s...`);
+          await new Promise(r => setTimeout(r, delay));
+        } else {
+          await unlink(cookieJarPath).catch(() => {});
+          throw new Error('Download returned HTML after retries — CDN may be unavailable or session expired. Re-run: npx notebooklm export-session');
+        }
       }
+    }
+
+    if (lastError && !(await readFile(filePath).catch(() => null))) {
+      await unlink(cookieJarPath).catch(() => {});
+      throw new Error(`Download failed: ${lastError}`);
     }
 
     await unlink(cookieJarPath).catch(() => {});

--- a/src/client.ts
+++ b/src/client.ts
@@ -1202,6 +1202,7 @@ export class NotebookClient {
     const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
       type: 'flashcards',
       instructions: options.instructions,
+      language: options.language,
       quantity: options.quantity,
       difficulty: options.difficulty,
     });
@@ -1325,6 +1326,7 @@ export class NotebookClient {
     const { artifactId } = await this.generateArtifact(notebookId, ARTIFACT_TYPE.QUIZ, sourceIds, {
       type: 'quiz',
       instructions: options.instructions,
+      language: options.language,
       quantity: options.quantity,
       difficulty: options.difficulty,
     });

--- a/src/transport-curl.ts
+++ b/src/transport-curl.ts
@@ -6,6 +6,8 @@
  */
 
 import { execFile as execFileCb } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { platform } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -71,6 +73,13 @@ export class CurlTransport implements Transport {
       const body = new URLSearchParams(req.body).toString();
       const headers = this.buildHeaders();
 
+      // Write cookies to a temp file to avoid exceeding OS argument length limits.
+      // Google sessions carry many large cookies that easily blow past ARG_MAX
+      // when passed via -H "Cookie: ...".
+      const cookieFilePath = join(tmpdir(), `.nblm-curl-cookies-${process.pid}-${Date.now()}`);
+      const cookieFileContent = this.buildCookieFile();
+      writeFileSync(cookieFilePath, cookieFileContent, 'utf-8');
+
       const args: string[] = [
         '--impersonate', 'chrome136',
         url,
@@ -79,6 +88,7 @@ export class CurlTransport implements Transport {
         '-X', 'POST',
         '--data', body,
         '-w', '\n%{http_code}', // append status code
+        '-b', cookieFilePath,  // read cookies from file
       ];
 
       if (this.proxy) {
@@ -89,28 +99,32 @@ export class CurlTransport implements Transport {
         args.push('-H', `${key}: ${value}`);
       }
 
-      const { stdout, stderr } = await execFileAsync(this.binaryPath, args, {
-        timeout: 60_000,
-        maxBuffer: 10 * 1024 * 1024,
-      });
+      try {
+        const { stdout, stderr } = await execFileAsync(this.binaryPath, args, {
+          timeout: 60_000,
+          maxBuffer: 10 * 1024 * 1024,
+        });
 
-      if (stderr && stderr.includes('curl:')) {
-        throw new Error(`curl-impersonate error: ${stderr.trim()}`);
+        if (stderr && stderr.includes('curl:')) {
+          throw new Error(`curl-impersonate error: ${stderr.trim()}`);
+        }
+
+        // Response format: <body>\n<status_code>
+        const lastNewline = stdout.lastIndexOf('\n');
+        const responseBody = lastNewline > 0 ? stdout.slice(0, lastNewline) : stdout;
+        const statusCode = lastNewline > 0 ? parseInt(stdout.slice(lastNewline + 1).trim(), 10) : 200;
+
+        if (statusCode === 401 || statusCode === 400) {
+          throw new SessionError(`HTTP ${statusCode}`);
+        }
+        if (statusCode < 200 || statusCode >= 300) {
+          throw new Error(`HTTP ${statusCode}: ${responseBody.slice(0, 200)}`);
+        }
+
+        return responseBody;
+      } finally {
+        try { unlinkSync(cookieFilePath); } catch { /* ignore cleanup errors */ }
       }
-
-      // Response format: <body>\n<status_code>
-      const lastNewline = stdout.lastIndexOf('\n');
-      const responseBody = lastNewline > 0 ? stdout.slice(0, lastNewline) : stdout;
-      const statusCode = lastNewline > 0 ? parseInt(stdout.slice(lastNewline + 1).trim(), 10) : 200;
-
-      if (statusCode === 401 || statusCode === 400) {
-        throw new SessionError(`HTTP ${statusCode}`);
-      }
-      if (statusCode < 200 || statusCode >= 300) {
-        throw new Error(`HTTP ${statusCode}: ${responseBody.slice(0, 200)}`);
-      }
-
-      return responseBody;
     };
 
     try {
@@ -147,10 +161,10 @@ export class CurlTransport implements Transport {
 
   private buildHeaders(): Record<string, string> {
     const ua = this.session.userAgent || DEFAULT_USER_AGENT;
+    // Cookie is passed via -b <file> to avoid exceeding OS argument length limits
     return {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
       'User-Agent': ua,
-      'Cookie': this.session.cookies,
       'Origin': 'https://notebooklm.google.com',
       'Referer': 'https://notebooklm.google.com/',
       'Accept': '*/*',
@@ -163,6 +177,35 @@ export class CurlTransport implements Transport {
       'Sec-Fetch-Site': 'same-origin',
       'X-Same-Domain': '1',
     };
+  }
+
+  /** Build a Netscape-format cookie file from session cookies. */
+  private buildCookieFile(): string {
+    const lines = ['# Netscape HTTP Cookie File'];
+    const session = this.session;
+
+    if (session.cookieJar && session.cookieJar.length > 0) {
+      for (const c of session.cookieJar) {
+        const isDotDomain = c.domain.startsWith('.');
+        const domainFlag = isDotDomain ? 'TRUE' : 'FALSE';
+        const secure = c.secure ? 'TRUE' : 'FALSE';
+        const path = c.path ?? '/';
+        lines.push(`${c.domain}\t${domainFlag}\t${path}\t${secure}\t0\t${c.name}\t${c.value}`);
+      }
+    } else {
+      // Fallback: parse flat cookie string → scope to .google.com
+      for (const pair of session.cookies.split(';')) {
+        const eq = pair.indexOf('=');
+        if (eq > 0) {
+          const name = pair.slice(0, eq).trim();
+          const value = pair.slice(eq + 1).trim();
+          const secure = name.startsWith('__Secure') || name.startsWith('__Host') ? 'TRUE' : 'FALSE';
+          lines.push(`.google.com\tTRUE\t/\t${secure}\t0\t${name}\t${value}`);
+        }
+      }
+    }
+
+    return lines.join('\n');
   }
 
   // ── Static Detection ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface VideoArtifactOptions {
 export interface QuizArtifactOptions {
   type: 'quiz';
   instructions?: string;
+  language?: string;
   quantity?: QuizQuantity;
   difficulty?: QuizDifficulty;
 }
@@ -95,6 +96,7 @@ export interface QuizArtifactOptions {
 export interface FlashcardsArtifactOptions {
   type: 'flashcards';
   instructions?: string;
+  language?: string;
   quantity?: QuizQuantity;
   difficulty?: QuizDifficulty;
 }
@@ -160,6 +162,7 @@ export interface FlashcardsOptions {
   source: SourceInput;
   outputDir: string;
   instructions?: string;
+  language?: string;
   quantity?: QuizQuantity;
   difficulty?: QuizDifficulty;
 }
@@ -185,6 +188,7 @@ export interface QuizOptions {
   source: SourceInput;
   outputDir: string;
   instructions?: string;
+  language?: string;
   quantity?: QuizQuantity;
   difficulty?: QuizDifficulty;
 }

--- a/tests/transport-curl.test.ts
+++ b/tests/transport-curl.test.ts
@@ -2,11 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { NotebookRpcSession } from '../src/types.js';
 import type { TransportRequest } from '../src/transport.js';
 
-// Mock child_process before importing CurlTransport
+// Mock child_process and fs before importing CurlTransport
 const mockExecFile = vi.fn();
 vi.mock('node:child_process', () => ({
   execFile: mockExecFile,
 }));
+
+let lastWrittenCookieFile = '';
+let lastWrittenCookieContent = '';
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    writeFileSync: (path: string, content: string) => {
+      lastWrittenCookieFile = path;
+      lastWrittenCookieContent = content;
+    },
+    unlinkSync: () => {},
+  };
+});
 
 const { CurlTransport } = await import('../src/transport-curl.js');
 
@@ -79,7 +93,17 @@ describe('CurlTransport', () => {
     expect(capturedArgs).toContain('--compressed');
 
     const headerValues = capturedArgs.filter((_: string, i: number) => capturedArgs[i - 1] === '-H');
-    expect(headerValues.some((h: string) => h.includes('Cookie: SID=abc'))).toBe(true);
+    // Cookie should NOT be in -H args (passed via -b cookie file instead)
+    expect(headerValues.some((h: string) => h.includes('Cookie:'))).toBe(false);
+    // Cookie should be in -b file arg
+    expect(capturedArgs).toContain('-b');
+    const bIdx = capturedArgs.indexOf('-b');
+    expect(capturedArgs[bIdx + 1]).toContain('nblm-curl-cookies');
+    // Cookie content should be written to file in Netscape format
+    expect(lastWrittenCookieContent).toContain('# Netscape HTTP Cookie File');
+    expect(lastWrittenCookieContent).toContain('SID');
+    expect(lastWrittenCookieContent).toContain('abc');
+
     expect(headerValues.some((h: string) => h.includes('X-Same-Domain: 1'))).toBe(true);
     expect(headerValues.some((h: string) => h.includes('Sec-Fetch-Mode: cors'))).toBe(true);
     expect(headerValues.some((h: string) => h.includes('Origin: https://notebooklm.google.com'))).toBe(true);


### PR DESCRIPTION
## Summary

- `detail` 命令新增 Studio artifacts 展示（类型、标题、时长）
- 修复 `getInteractiveHtml` 解析：HTML 被包裹在单元素数组里导致 quiz/flashcards 内容为空
- 修复信息图下载：curl-impersonate TLS 被 lh3.google.com 拒绝时 fallback 到系统 curl
- 修复 `downloadFileHttp` retry 逻辑：curl 执行报错时也重试（之前只重试 HTML 响应）
- 修复误导性错误信息 "Audio download failed" → "Download failed"

## Detail command output (after)

```
Title: My Notebook
Sources (1):
  abc123  My Source [500 words]
Studio (3):
  def456  [audio] Deep Dive Podcast [15m]
  ghi789  [quiz] Knowledge Check
  jkl012  [infographic] Visual Summary
```

## Test plan

- [ ] `detail` 命令展示 Studio artifacts
- [ ] `getArtifacts` 失败时仍正常展示 sources
- [ ] quiz/flashcards HTML 有内容
- [ ] 信息图通过系统 curl fallback 下载成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)