### PR TITLE
test: add unit tests for 'source add' command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import type { TransportMode } from './client.js';
 import { setHomeDir } from './paths.js';
 import type { SourceInput, WorkflowProgress } from './types.js';
 import { ARTIFACT_TYPE } from './rpc-ids.js';
+import { runSourceAdd, validateSourceAddOpts, type SourceAddOpts } from './commands/source-add.js';
 
 const program = new Command();
 
@@ -561,26 +562,10 @@ addBrowserOptions(sourceAddCmd)
   .option('--url <url>', 'Source URL')
   .option('--text <content>', 'Source text content')
   .option('--title <title>', 'Title for text source (default: "Pasted Text")')
-  .action(async (notebookId: string, opts) => {
-    const provided = [opts.file, opts.url, opts.text].filter((v) => v !== undefined).length;
-    if (provided !== 1) {
-      throw new Error('Specify exactly one of --file, --url, or --text');
-    }
-    if (opts.text !== undefined && opts.text.length === 0) {
-      throw new Error('--text must not be empty');
-    }
-    if (opts.title !== undefined && opts.text === undefined) {
-      throw new Error('--title only applies to --text');
-    }
+  .action(async (notebookId: string, opts: SourceAddOpts & Parameters<typeof withClient>[0]) => {
+    validateSourceAddOpts(opts);
     await withClient(opts, async (client) => {
-      let result: { sourceId: string; title: string };
-      if (opts.file !== undefined) {
-        result = await client.addFileSource(notebookId, opts.file);
-      } else if (opts.url !== undefined) {
-        result = await client.addUrlSource(notebookId, opts.url);
-      } else {
-        result = await client.addTextSource(notebookId, opts.title ?? 'Pasted Text', opts.text);
-      }
+      const result = await runSourceAdd(client, notebookId, opts);
       console.log(`Added: ${result.sourceId}  ${result.title}`);
     });
   });

--- a/src/commands/source-add.ts
+++ b/src/commands/source-add.ts
@@ -1,0 +1,40 @@
+export interface SourceAddOpts {
+  file?: string;
+  url?: string;
+  text?: string;
+  title?: string;
+}
+
+export interface SourceAddClient {
+  addFileSource(notebookId: string, filePath: string): Promise<{ sourceId: string; title: string }>;
+  addUrlSource(notebookId: string, url: string): Promise<{ sourceId: string; title: string }>;
+  addTextSource(notebookId: string, title: string, content: string): Promise<{ sourceId: string; title: string }>;
+}
+
+export function validateSourceAddOpts(opts: SourceAddOpts): void {
+  const provided = [opts.file, opts.url, opts.text].filter((v) => v !== undefined).length;
+  if (provided !== 1) {
+    throw new Error('Specify exactly one of --file, --url, or --text');
+  }
+  if (opts.text !== undefined && opts.text.trim().length === 0) {
+    throw new Error('--text must not be empty');
+  }
+  if (opts.title !== undefined && opts.text === undefined) {
+    throw new Error('--title only applies to --text');
+  }
+}
+
+export async function runSourceAdd(
+  client: SourceAddClient,
+  notebookId: string,
+  opts: SourceAddOpts,
+): Promise<{ sourceId: string; title: string }> {
+  validateSourceAddOpts(opts);
+  if (opts.file !== undefined) {
+    return client.addFileSource(notebookId, opts.file);
+  }
+  if (opts.url !== undefined) {
+    return client.addUrlSource(notebookId, opts.url);
+  }
+  return client.addTextSource(notebookId, opts.title ?? 'Pasted Text', opts.text as string);
+}

--- a/tests/source-add.test.ts
+++ b/tests/source-add.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runSourceAdd,
+  validateSourceAddOpts,
+  type SourceAddClient,
+  type SourceAddOpts,
+} from '../src/commands/source-add.js';
+
+function makeClient(): SourceAddClient & {
+  addFileSource: ReturnType<typeof vi.fn>;
+  addUrlSource: ReturnType<typeof vi.fn>;
+  addTextSource: ReturnType<typeof vi.fn>;
+} {
+  return {
+    addFileSource: vi.fn().mockResolvedValue({ sourceId: 'file-1', title: 'file.pdf' }),
+    addUrlSource: vi.fn().mockResolvedValue({ sourceId: 'url-1', title: 'Example' }),
+    addTextSource: vi.fn().mockResolvedValue({ sourceId: 'text-1', title: 'Pasted Text' }),
+  };
+}
+
+describe('validateSourceAddOpts', () => {
+  it('rejects when no flag given', () => {
+    expect(() => validateSourceAddOpts({})).toThrow(/exactly one/);
+  });
+
+  it('rejects when two flags given', () => {
+    expect(() => validateSourceAddOpts({ file: 'a.pdf', url: 'https://x' })).toThrow(/exactly one/);
+  });
+
+  it('rejects when all three flags given', () => {
+    expect(() => validateSourceAddOpts({ file: 'a.pdf', url: 'https://x', text: 'hi' })).toThrow(
+      /exactly one/,
+    );
+  });
+
+  it('accepts a single flag', () => {
+    expect(() => validateSourceAddOpts({ file: 'a.pdf' })).not.toThrow();
+    expect(() => validateSourceAddOpts({ url: 'https://x' })).not.toThrow();
+    expect(() => validateSourceAddOpts({ text: 'hello' })).not.toThrow();
+  });
+
+  it('rejects empty text', () => {
+    expect(() => validateSourceAddOpts({ text: '' })).toThrow(/must not be empty/);
+  });
+
+  it('rejects whitespace-only text', () => {
+    expect(() => validateSourceAddOpts({ text: '   \n\t' })).toThrow(/must not be empty/);
+  });
+
+  it('rejects --title without --text', () => {
+    expect(() => validateSourceAddOpts({ file: 'a.pdf', title: 'My Note' })).toThrow(
+      /--title only applies to --text/,
+    );
+  });
+
+  it('accepts --title with --text', () => {
+    expect(() => validateSourceAddOpts({ text: 'hello', title: 'My Note' })).not.toThrow();
+  });
+});
+
+describe('runSourceAdd dispatch', () => {
+  it('dispatches --file to addFileSource', async () => {
+    const client = makeClient();
+    const result = await runSourceAdd(client, 'nb-1', { file: '/tmp/a.pdf' });
+    expect(client.addFileSource).toHaveBeenCalledWith('nb-1', '/tmp/a.pdf');
+    expect(client.addUrlSource).not.toHaveBeenCalled();
+    expect(client.addTextSource).not.toHaveBeenCalled();
+    expect(result).toEqual({ sourceId: 'file-1', title: 'file.pdf' });
+  });
+
+  it('dispatches --url to addUrlSource', async () => {
+    const client = makeClient();
+    const result = await runSourceAdd(client, 'nb-1', { url: 'https://example.com/a.pdf' });
+    expect(client.addUrlSource).toHaveBeenCalledWith('nb-1', 'https://example.com/a.pdf');
+    expect(client.addFileSource).not.toHaveBeenCalled();
+    expect(client.addTextSource).not.toHaveBeenCalled();
+    expect(result).toEqual({ sourceId: 'url-1', title: 'Example' });
+  });
+
+  it('dispatches --text with default title', async () => {
+    const client = makeClient();
+    await runSourceAdd(client, 'nb-1', { text: 'hello world' });
+    expect(client.addTextSource).toHaveBeenCalledWith('nb-1', 'Pasted Text', 'hello world');
+  });
+
+  it('dispatches --text with custom --title', async () => {
+    const client = makeClient();
+    await runSourceAdd(client, 'nb-1', { text: 'hello world', title: 'My Note' });
+    expect(client.addTextSource).toHaveBeenCalledWith('nb-1', 'My Note', 'hello world');
+  });
+
+  it('validates before dispatching', async () => {
+    const client = makeClient();
+    await expect(runSourceAdd(client, 'nb-1', {})).rejects.toThrow(/exactly one/);
+    expect(client.addFileSource).not.toHaveBeenCalled();
+    expect(client.addUrlSource).not.toHaveBeenCalled();
+    expect(client.addTextSource).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Follow-up to #14. Stacked on top of that PR's branch, so the diff here temporarily includes #14's commits; once #14 merges those drop out and only the test delta remains.

## Summary

- Extract the `source add` handler from `src/cli.ts` into `src/commands/source-add.ts` (`runSourceAdd` + `validateSourceAddOpts`) so it can be unit-tested without opening a transport.
- Add 13 unit tests covering all validation branches and dispatch paths.
- Tighten empty-text check: reject whitespace-only input (`--text "   "`) rather than forwarding it to the server.

## Why a separate PR

#14 landed the feature and its smoke tests, but had no unit coverage for the new validation/dispatch logic. Project convention is "无测试 = 未完成", so filling the gap as a follow-up keeps #14's scope clean.

## Test coverage

**validateSourceAddOpts** (8 tests)
- 0 / 2 / 3 flags → \`exactly one\`
- single flag (file / url / text) → ok
- empty text, whitespace-only text → \`must not be empty\`
- \`--title\` without \`--text\` → \`--title only applies to --text\`
- \`--title\` with \`--text\` → ok

**runSourceAdd dispatch** (5 tests)
- \`--file\` → \`addFileSource\`
- \`--url\` → \`addUrlSource\`
- \`--text\` → \`addTextSource('Pasted Text', ...)\`
- \`--text --title\` → \`addTextSource(<custom>, ...)\`
- invalid opts → no client method called

## Test plan

- [x] \`npm test\` — 126 tests pass (113 existing + 13 new)
- [x] \`npm run build\` — \`tsc\` clean
- [ ] Manual smoke: \`npx notebooklm source add <id> --file ...\` against a real notebook (should behave identically to pre-refactor; only code path moved)