### PR TITLE
Strengthen validation for CLI source input combinations

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,10 @@ import { Command } from 'commander';
 import { NotebookClient } from './client.js';
 import type { TransportMode } from './client.js';
 import { setHomeDir } from './paths.js';
-import type { SourceInput, WorkflowProgress } from './types.js';
+import type { WorkflowProgress } from './types.js';
 import { ARTIFACT_TYPE } from './rpc-ids.js';
 import { runSourceAdd, validateSourceAddOpts, type SourceAddOpts } from './commands/source-add.js';
+import { buildSourceInput } from './commands/source-input.js';
 
 const program = new Command();
 
@@ -51,14 +52,6 @@ function addSourceOptions(cmd: Command): Command {
     .option('--file <path>', 'Local file path (pdf, txt, md, docx, csv, pptx, epub, mp3, wav, etc.)')
     .option('--topic <topic>', 'Research topic')
     .option('--research-mode <mode>', 'Research mode: fast or deep', 'fast');
-}
-
-function buildSource(opts: { url?: string; text?: string; file?: string; topic?: string; researchMode?: string }): SourceInput {
-  if (opts.url) return { type: 'url', url: opts.url };
-  if (opts.text) return { type: 'text', text: opts.text };
-  if (opts.file) return { type: 'file', filePath: opts.file };
-  if (opts.topic) return { type: 'research', topic: opts.topic, researchMode: (opts.researchMode as 'fast' | 'deep') ?? 'fast' };
-  throw new Error('Must specify --url, --text, --file, or --topic');
 }
 
 async function withClient(
@@ -212,7 +205,7 @@ addBrowserOptions(addSourceOptions(audioCmd))
   .option('--length <len>', 'Audio length: short | default | long')
   .option('--keep-notebook', 'Do not delete the notebook after completion')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runAudioOverview(
         {
@@ -242,7 +235,7 @@ const analyzeCmd = new Command('analyze')
 addBrowserOptions(addSourceOptions(analyzeCmd))
   .requiredOption('--question <q>', 'Question to ask about the source')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runAnalyze(
         { source, question: opts.question },
@@ -266,7 +259,7 @@ addBrowserOptions(addSourceOptions(reportCmd))
   .option('--instructions <text>', 'Custom instructions (appended to template, or full prompt for custom)')
   .option('-l, --language <lang>', 'Output language', 'en')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runReport(
         {
@@ -297,7 +290,7 @@ addBrowserOptions(addSourceOptions(videoCmd))
   .option('--instructions <text>', 'Custom instructions')
   .option('-l, --language <lang>', 'Output language', 'en')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runVideo(
         {
@@ -329,7 +322,7 @@ addBrowserOptions(addSourceOptions(quizCmd))
   .option('--quantity <q>', 'Quiz quantity: fewer | standard')
   .option('--difficulty <d>', 'Quiz difficulty: easy | medium | hard')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runQuiz(
         {
@@ -361,7 +354,7 @@ addBrowserOptions(addSourceOptions(flashcardsCmd))
   .option('--quantity <q>', 'Flashcard quantity: fewer | standard')
   .option('--difficulty <d>', 'Flashcard difficulty: easy | medium | hard')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runFlashcards(
         {
@@ -394,7 +387,7 @@ addBrowserOptions(addSourceOptions(infographicCmd))
   .option('--detail <d>', 'Detail level: concise | standard | detailed')
   .option('--style <s>', 'Style: sketch_note | professional | bento_grid')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runInfographic(
         {
@@ -427,7 +420,7 @@ addBrowserOptions(addSourceOptions(slidesCmd))
   .option('--format <fmt>', 'Slide format: detailed | presenter')
   .option('--length <len>', 'Slide length: default | short')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runSlideDeck(
         {
@@ -458,7 +451,7 @@ addBrowserOptions(addSourceOptions(dataTableCmd))
   .option('--instructions <text>', 'Custom instructions (describe desired table structure)')
   .option('-l, --language <lang>', 'Output language', 'en')
   .action(async (opts) => {
-    const source = buildSource(opts);
+    const source = buildSourceInput(opts);
     await withClient(opts, async (client) => {
       const result = await client.runDataTable(
         {

--- a/src/commands/source-input.ts
+++ b/src/commands/source-input.ts
@@ -1,0 +1,38 @@
+import type { ResearchMode, SourceInput } from '../types.js';
+
+export interface SourceInputOpts {
+  url?: string;
+  text?: string;
+  file?: string;
+  topic?: string;
+  researchMode?: string;
+}
+
+export function validateSourceInputOpts(opts: SourceInputOpts): void {
+  const provided = [opts.url, opts.text, opts.file, opts.topic].filter((value) => value !== undefined).length;
+  if (provided !== 1) {
+    throw new Error('Specify exactly one of --url, --text, --file, or --topic');
+  }
+  if (opts.text !== undefined && opts.text.trim().length === 0) {
+    throw new Error('--text must not be empty');
+  }
+}
+
+export function buildSourceInput(opts: SourceInputOpts): SourceInput {
+  validateSourceInputOpts(opts);
+  if (opts.url !== undefined) return { type: 'url', url: opts.url };
+  if (opts.text !== undefined) return { type: 'text', text: opts.text };
+  if (opts.file !== undefined) return { type: 'file', filePath: opts.file };
+  if (opts.topic === undefined) {
+    throw new Error('Specify exactly one of --url, --text, --file, or --topic');
+  }
+  return {
+    type: 'research',
+    topic: opts.topic,
+    researchMode: resolveResearchMode(opts.researchMode),
+  };
+}
+
+function resolveResearchMode(mode?: string): ResearchMode {
+  return mode === 'deep' ? 'deep' : 'fast';
+}

--- a/src/commands/source-input.ts
+++ b/src/commands/source-input.ts
@@ -9,12 +9,13 @@ export interface SourceInputOpts {
 }
 
 export function validateSourceInputOpts(opts: SourceInputOpts): void {
-  const provided = [opts.url, opts.text, opts.file, opts.topic].filter((value) => value !== undefined).length;
-  if (provided !== 1) {
-    throw new Error('Specify exactly one of --url, --text, --file, or --topic');
-  }
   if (opts.text !== undefined && opts.text.trim().length === 0) {
     throw new Error('--text must not be empty');
+  }
+
+  const provided = [opts.url, opts.text, opts.file, opts.topic].filter(Boolean).length;
+  if (provided !== 1) {
+    throw new Error('Specify exactly one of --url, --text, --file, or --topic');
   }
 }
 

--- a/tests/source-input.test.ts
+++ b/tests/source-input.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { buildSourceInput, validateSourceInputOpts } from '../src/commands/source-input.js';
+
+describe('validateSourceInputOpts', () => {
+  it('rejects when no source flag is given', () => {
+    expect(() => validateSourceInputOpts({})).toThrow(/exactly one/);
+  });
+
+  it('rejects when multiple source flags are given', () => {
+    expect(() => validateSourceInputOpts({ url: 'https://example.com', file: '/tmp/a.pdf' })).toThrow(/exactly one/);
+    expect(() => validateSourceInputOpts({ text: 'hello', topic: 'ai' })).toThrow(/exactly one/);
+  });
+
+  it('rejects empty text', () => {
+    expect(() => validateSourceInputOpts({ text: '' })).toThrow(/must not be empty/);
+    expect(() => validateSourceInputOpts({ text: '   \n\t' })).toThrow(/must not be empty/);
+  });
+});
+
+describe('buildSourceInput', () => {
+  it('builds a url source', () => {
+    expect(buildSourceInput({ url: 'https://example.com' })).toEqual({
+      type: 'url',
+      url: 'https://example.com',
+    });
+  });
+
+  it('builds a text source', () => {
+    expect(buildSourceInput({ text: 'hello' })).toEqual({
+      type: 'text',
+      text: 'hello',
+    });
+  });
+
+  it('builds a file source', () => {
+    expect(buildSourceInput({ file: '/tmp/a.pdf' })).toEqual({
+      type: 'file',
+      filePath: '/tmp/a.pdf',
+    });
+  });
+
+  it('builds a research source with default mode', () => {
+    expect(buildSourceInput({ topic: 'quantum computing' })).toEqual({
+      type: 'research',
+      topic: 'quantum computing',
+      researchMode: 'fast',
+    });
+  });
+
+  it('builds a research source with explicit mode', () => {
+    expect(buildSourceInput({ topic: 'quantum computing', researchMode: 'deep' })).toEqual({
+      type: 'research',
+      topic: 'quantum computing',
+      researchMode: 'deep',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- enforce validation for mutually dependent and conflicting source input options before command execution
- move source input parsing and normalization into a dedicated module to keep CLI command handling focused
- add unit coverage for accepted and rejected source input combinations

## Testing
- [x] Existing automated test suite
- [x] Source input unit tests