### PR TITLE
fix(data-table): stop saving prompt-echo CSV instead of real table

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -403,6 +403,13 @@ export async function saveInfographic(
  * only `section[0] !== null` is not strict enough — an absent slot is
  * `undefined`, and the server can also emit transient `'loading'`-style
  * strings or an empty data array before the rows are filled.
+ *
+ * Tradeoff: if the backend ever finalizes a data-table artifact with an
+ * empty rows array (a valid but vacuous table), saveDataTable will poll
+ * until timeout and fall back to the JSON dump. That is accepted as the
+ * safer default vs. treating a mid-generation empty array as final,
+ * which would silently save an empty result while real rows were still
+ * on the way.
  */
 export function isDataTableReady(meta: unknown[]): boolean {
   const section = meta[18];

--- a/src/download.ts
+++ b/src/download.ts
@@ -393,43 +393,64 @@ export async function saveInfographic(
   return download(imageUrl, outputDir, `infographic_${Date.now()}.png`);
 }
 
+/**
+ * Ready predicate for data-table artifact metadata.
+ *
+ * The server returns an initial placeholder of `[null, [prompt, lang]]` at
+ * `meta[18]` as soon as generation starts — that already has length 2, so
+ * a naive `section.length >= 2` check would return true immediately and
+ * callers would treat the unpopulated placeholder as "ready". The real
+ * table data lives at `section[0]`; wait until that slot is non-null.
+ */
+export function isDataTableReady(meta: unknown[]): boolean {
+  const section = meta[18];
+  return Array.isArray(section) && section[0] !== null;
+}
+
+/**
+ * Convert ready data-table metadata into CSV text. Returns null when no
+ * rows can be extracted (caller falls back to dumping raw JSON).
+ *
+ * Only `section[0]` (the data node) is walked. `section[1]` is the
+ * `[prompt, lang]` echoed back by the server; feeding it to the walker
+ * would emit a phantom row whose cells are the user's prompt + language
+ * code, which is how the "CSV-is-just-my-prompt" bug used to surface.
+ */
+export function extractDataTableCsv(meta: unknown[]): string | null {
+  const section = meta[18];
+  if (!Array.isArray(section)) return null;
+  const dataNode = section[0];
+  if (!Array.isArray(dataNode)) return null;
+  const rows = extractTableRows(dataNode as unknown[]);
+  if (rows.length === 0) return null;
+  return rows
+    .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+}
+
 /** Save data table — poll metadata for table data, save as CSV. */
 export async function saveDataTable(
   callRpc: RpcCaller,
   artifactId: string,
   outputDir: string,
 ): Promise<string> {
-  const meta = await pollArtifactMetadata(callRpc, artifactId, (m) => {
-    const section = m[18];
-    return Array.isArray(section) && section.length >= 2;
-  });
+  const meta = await pollArtifactMetadata(callRpc, artifactId, isDataTableReady);
 
   mkdirSync(outputDir, { recursive: true });
 
-  const section = meta[18];
-  let csvContent = '';
-
-  if (Array.isArray(section)) {
-    const rows = extractTableRows(section);
-    if (rows.length > 0) {
-      csvContent = rows.map(row =>
-        row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','),
-      ).join('\n');
-    }
-  }
-
-  if (!csvContent) {
+  const csv = extractDataTableCsv(meta);
+  if (csv === null) {
     const filePath = join(outputDir, `data_table_${Date.now()}.json`);
-    writeFileSync(filePath, JSON.stringify(section, null, 2), 'utf-8');
+    writeFileSync(filePath, JSON.stringify(meta[18], null, 2), 'utf-8');
     return filePath;
   }
 
   const filePath = join(outputDir, `data_table_${Date.now()}.csv`);
-  writeFileSync(filePath, csvContent, 'utf-8');
+  writeFileSync(filePath, csv, 'utf-8');
   return filePath;
 }
 
-/** Try to extract rows from data table metadata. */
+/** Walk metadata recursively, emitting rows that look like flat cell arrays. */
 export function extractTableRows(data: unknown[]): string[][] {
   const rows: string[][] = [];
   function walk(val: unknown): void {

--- a/src/download.ts
+++ b/src/download.ts
@@ -396,15 +396,19 @@ export async function saveInfographic(
 /**
  * Ready predicate for data-table artifact metadata.
  *
- * The server returns an initial placeholder of `[null, [prompt, lang]]` at
- * `meta[18]` as soon as generation starts — that already has length 2, so
- * a naive `section.length >= 2` check would return true immediately and
- * callers would treat the unpopulated placeholder as "ready". The real
- * table data lives at `section[0]`; wait until that slot is non-null.
+ * The server's initial placeholder at `meta[18]` is `[null, [prompt, lang]]`
+ * — the naive `length >= 2` check used previously returned true immediately.
+ * The real table data lives at `section[0]`, and must match what
+ * `extractDataTableCsv` can actually consume: a non-empty array. Requiring
+ * only `section[0] !== null` is not strict enough — an absent slot is
+ * `undefined`, and the server can also emit transient `'loading'`-style
+ * strings or an empty data array before the rows are filled.
  */
 export function isDataTableReady(meta: unknown[]): boolean {
   const section = meta[18];
-  return Array.isArray(section) && section[0] !== null;
+  if (!Array.isArray(section)) return false;
+  const dataNode = section[0];
+  return Array.isArray(dataNode) && dataNode.length > 0;
 }
 
 /**

--- a/tests/data-table.test.ts
+++ b/tests/data-table.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractTableRows,
+  extractDataTableCsv,
+  isDataTableReady,
+} from '../src/download.js';
+
+function metaWithSection18(section18: unknown): unknown[] {
+  const meta: unknown[] = Array(19).fill(null);
+  meta[18] = section18;
+  return meta;
+}
+
+describe('isDataTableReady', () => {
+  it('rejects when meta has no section 18', () => {
+    expect(isDataTableReady([])).toBe(false);
+  });
+
+  it('rejects when section 18 is not an array', () => {
+    expect(isDataTableReady(metaWithSection18('not-array'))).toBe(false);
+    expect(isDataTableReady(metaWithSection18(null))).toBe(false);
+  });
+
+  it('rejects the initial placeholder [null, [prompt, lang]]', () => {
+    const meta = metaWithSection18([null, ['Render a revenue table', 'en']]);
+    expect(isDataTableReady(meta)).toBe(false);
+  });
+
+  it('accepts fully populated section with data node and prompt echo', () => {
+    const meta = metaWithSection18([
+      [['h1', 'h2'], ['a', 'b']],
+      ['Render a revenue table', 'en'],
+    ]);
+    expect(isDataTableReady(meta)).toBe(true);
+  });
+
+  it('accepts a section whose only entry is the data node', () => {
+    const meta = metaWithSection18([[['h1', 'h2']]]);
+    expect(isDataTableReady(meta)).toBe(true);
+  });
+});
+
+describe('extractTableRows', () => {
+  it('returns no rows for an empty array', () => {
+    expect(extractTableRows([])).toEqual([]);
+  });
+
+  it('treats a flat array of nulls as a row of empty cells', () => {
+    expect(extractTableRows([null, null])).toEqual([['', '']]);
+  });
+
+  it('extracts a single flat row', () => {
+    expect(extractTableRows([['a', 'b', 'c']])).toEqual([['a', 'b', 'c']]);
+  });
+
+  it('extracts multiple rows from a nested structure', () => {
+    const input = [
+      [
+        ['h1', 'h2', 'h3'],
+        ['r1c1', 'r1c2', 'r1c3'],
+        ['r2c1', 'r2c2', 'r2c3'],
+      ],
+    ];
+    expect(extractTableRows(input)).toEqual([
+      ['h1', 'h2', 'h3'],
+      ['r1c1', 'r1c2', 'r1c3'],
+      ['r2c1', 'r2c2', 'r2c3'],
+    ]);
+  });
+
+  it('stringifies numbers and blanks out nulls in cells', () => {
+    expect(extractTableRows([['a', 1, null]])).toEqual([['a', '1', '']]);
+  });
+});
+
+describe('extractDataTableCsv', () => {
+  it('returns null for placeholder meta (section[0] is null)', () => {
+    const meta = metaWithSection18([null, ['Render a revenue table', 'en']]);
+    expect(extractDataTableCsv(meta)).toBeNull();
+  });
+
+  it('returns null when meta has no section 18', () => {
+    expect(extractDataTableCsv([])).toBeNull();
+  });
+
+  it('returns null when section 18 is not an array', () => {
+    expect(extractDataTableCsv(metaWithSection18('junk'))).toBeNull();
+  });
+
+  it('returns null when the data node is empty', () => {
+    const meta = metaWithSection18([[], ['Render a revenue table', 'en']]);
+    expect(extractDataTableCsv(meta)).toBeNull();
+  });
+
+  it('ignores the [prompt, lang] echo at section[1]', () => {
+    const meta = metaWithSection18([
+      [
+        ['Revenue', '2024', '2025'],
+        ['Product A', '100', '120'],
+      ],
+      ['Render revenue by product', 'en'],
+    ]);
+    const csv = extractDataTableCsv(meta);
+    expect(csv).not.toBeNull();
+    expect(csv).not.toContain('Render revenue by product');
+    expect(csv).toBe('"Revenue","2024","2025"\n"Product A","100","120"');
+  });
+
+  it('escapes embedded double quotes by doubling them', () => {
+    const meta = metaWithSection18([[['simple', 'with "quotes"', 'with,comma']]]);
+    expect(extractDataTableCsv(meta)).toBe('"simple","with ""quotes""","with,comma"');
+  });
+});

--- a/tests/data-table.test.ts
+++ b/tests/data-table.test.ts
@@ -21,8 +21,22 @@ describe('isDataTableReady', () => {
     expect(isDataTableReady(metaWithSection18(null))).toBe(false);
   });
 
+  it('rejects an empty section (section[0] is undefined)', () => {
+    expect(isDataTableReady(metaWithSection18([]))).toBe(false);
+  });
+
   it('rejects the initial placeholder [null, [prompt, lang]]', () => {
     const meta = metaWithSection18([null, ['Render a revenue table', 'en']]);
+    expect(isDataTableReady(meta)).toBe(false);
+  });
+
+  it('rejects a placeholder whose data slot is a non-array value', () => {
+    const meta = metaWithSection18(['loading', ['Render a revenue table', 'en']]);
+    expect(isDataTableReady(meta)).toBe(false);
+  });
+
+  it('rejects a placeholder whose data slot is an empty array', () => {
+    const meta = metaWithSection18([[], ['Render a revenue table', 'en']]);
     expect(isDataTableReady(meta)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- `notebooklm data-table` was saving a CSV whose only "row" was the
  user's prompt echoed back (e.g. `"Render a revenue table","en"`)
  instead of the generated table.
- The inline readiness predicate in `saveDataTable` checked only
  `section.length >= 2` on `meta[18]`. The server's placeholder is
  `[null, [prompt, lang]]`, whose length is already 2, so the poll
  returned true on the first iteration.
- `extractTableRows` was then handed the whole `section`, so the
  walker descended into `section[1]` (`[prompt, lang]`) and emitted
  it as a data row.
- Extract `isDataTableReady` and `extractDataTableCsv` as named pure
  functions (matching the pattern used in #15 / #16 for
  `source-add` / `source-input`). Readiness now requires `section[0]`
  to be a non-empty array — exactly what `extractDataTableCsv` can
  consume. `extractDataTableCsv` walks `section[0]` only, so the
  `[prompt, lang]` echo at `section[1]` is structurally excluded.

## Test plan

- [x] `npm test` — 145 tests pass (126 prior + 19 new in
  `tests/data-table.test.ts`)
- [x] `npm run build` — `tsc` clean
- [x] Unit coverage of the three affected paths:
  - `isDataTableReady` — 8 cases (placeholder shapes, non-array
    slot, empty data array, fully populated)
  - `extractTableRows` — 5 cases (existing walker behavior preserved)
  - `extractDataTableCsv` — 6 cases including explicit prompt-echo
    exclusion and CSV quoting

## Scope notes

- `pollArtifactReady` in `src/workflows.ts` returns eagerly for all
  non-media artifacts once the artifact id appears. That also affects
  `saveReport` / `saveSlideDeck` / `saveInfographic`, but each has a
  second-stage predicate whose content checks already filter out
  placeholders. Tightening `saveDataTable`'s own second-stage
  predicate is sufficient here; a broader refactor of the shared
  contract is left as a follow-up.
- The stricter `section[0].length > 0` condition means a backend that
  legitimately finalizes a data-table as an empty rows array would
  poll to timeout and then fall back to the existing JSON dump. This
  tradeoff is called out in the docstring — preferred over letting a
  mid-generation empty array be treated as final and silently saving
  an empty result while real rows are still on the way.
