### PR TITLE
fix(tls-client): verify module API shape so --transport auto falls through when tlsclientwrapper is incompatible

### DIFF
--- a/src/transport-tlsclient.ts
+++ b/src/transport-tlsclient.ts
@@ -175,9 +175,14 @@ export class TlsClientTransport implements Transport {
 
   // ── Static Detection ──
 
-  /** Check if tlsclientwrapper package is installed. */
+  /** Check if tlsclientwrapper package is installed with the expected API. */
   static async isAvailable(): Promise<boolean> {
-    return (await TlsClientTransport.loadModule()) !== null;
+    const mod = await TlsClientTransport.loadModule();
+    if (!mod) return false;
+    // v1.0.x exposed ModuleClient + SessionClient. v1.4+ replaced them with a
+    // single default `TlsClient` class, which this transport does not support.
+    // Verify the expected API shape so auto-detection falls through to http.
+    return typeof mod.ModuleClient === 'function' && typeof mod.SessionClient === 'function';
   }
 
   private static async loadModule(): Promise<TlsClientModule | null> {


### PR DESCRIPTION
## Summary

`--transport auto` currently crashes on any system where `curl-impersonate` is unavailable (notably **all Windows users**), even though the `http` fallback tier is perfectly functional. The root cause is that `TlsClientTransport.isAvailable()` only checks whether the `tlsclientwrapper` package can be imported, not whether it exposes the API this transport expects.

## Root cause

`package.json` pins the optional dependency loosely:

```json
"optionalDependencies": {
  "tlsclientwrapper": "^1.0.0"
}
```

`^1.0.0` resolves to the latest `1.x` on npm, which is currently **`1.4.3`**. Between `1.0.x` and `1.4.x`, the package was redesigned:

| version | exported API |
|---------|--------------|
| `1.0.x` | `ModuleClient` + `SessionClient` classes (used by this transport) |
| `1.4.x` | single default `TlsClient` class with bundled session state |

`transport-resolver.detectBestTier()` calls `TlsClientTransport.isAvailable()`, which returns `true` on `1.4.x` because the import succeeds. The resolver then picks the `tls-client` tier, and `TlsClientTransport.init()` blows up on the next line:

```
TypeError: mod.ModuleClient is not a constructor
    at TlsClientTransport.init (transport-tlsclient.ts:68)
```

## Reproduction

```bash
npm i notebooklm-client      # resolves tlsclientwrapper@1.4.3
npx notebooklm export-session
npx notebooklm list --transport auto
# → mod.ModuleClient is not a constructor
```

On Windows there is no `curl-impersonate` fallback, so `--transport auto` becomes unusable out of the box — users must manually pass `--transport browser`, which spawns a headless Chrome for every request.

## Fix

Verify the expected API shape inside `isAvailable()` so the resolver treats an incompatible `tlsclientwrapper` the same as a missing one and falls through to the `http` tier.

```ts
static async isAvailable(): Promise<boolean> {
  const mod = await TlsClientTransport.loadModule();
  if (!mod) return false;
  return typeof mod.ModuleClient === 'function'
      && typeof mod.SessionClient === 'function';
}
```

Minimal, defensive, no behavior change when `1.0.x` is present.

## Verification

Tested on Windows with `tlsclientwrapper@1.4.3` already installed in `node_modules`:

```
# Before
$ node dist/cli.js list --transport auto
mod.ModuleClient is not a constructor

# After
$ node dist/cli.js list --transport auto
NotebookLM: Connected via undici (tier 3, basic TLS) ...
<notebook list prints correctly>

$ node dist/cli.js chat <id> --transport auto --question "..."
<answer with citations>
```

Also confirmed `--transport tls-client` still raises the `not installed` error path when `isAvailable()` returns `false`, which is the intended behavior for an incompatible install.

## Follow-ups (not in this PR)

- Either add proper support for `tlsclientwrapper@1.4+` (rewrite the transport against the new `TlsClient` class), or tighten the range in `package.json` to `"tlsclientwrapper": "~1.0.0"` to keep tier 2 working. Happy to open a separate PR if preferred.
