### PR TITLE
fix: recover session refresh path (curl-impersonate + in-body auth detection)

### DIFF
--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -5,12 +5,26 @@
  */
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync, unlinkSync } from 'node:fs';
+import { execFile as execFileCb } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { Agent, ProxyAgent, request as undiciRequest } from 'undici';
-import { CHROME_CIPHERS } from './tls-config.js';
+import { CurlTransport } from './transport-curl.js';
 import { getSessionPath } from './paths.js';
 import type { NotebookRpcSession, SessionCookie } from './types.js';
+
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number; maxBuffer?: number } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFileCb(cmd, args, opts, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve({ stdout: stdout as string, stderr: stderr as string });
+    });
+  });
+}
 
 /**
  * Infer a domain-scoped cookieJar from a flat cookie string.
@@ -152,56 +166,91 @@ export async function refreshTokens(
   savePath?: string,
   proxy?: string,
 ): Promise<NotebookRpcSession> {
+  // Must use curl-impersonate: Google guards this endpoint with cookie-to-TLS
+  // fingerprint binding ("CookieMismatch"), which rejects Node/undici even
+  // with valid cookies. curl-impersonate reproduces Chrome's TLS + H2 signature.
+  const binaryPath = await CurlTransport.findBinary();
+  if (!binaryPath) {
+    throw new Error('Token refresh failed: curl-impersonate binary not found');
+  }
+
   const ua = session.userAgent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 
-  const dispatcher: Agent | ProxyAgent = proxy
-    ? new ProxyAgent({
-        uri: proxy,
-        requestTls: {
-          ciphers: CHROME_CIPHERS,
-          minVersion: 'TLSv1.2',
-          maxVersion: 'TLSv1.3',
-        },
-      })
-    : new Agent({
-        connect: {
-          ciphers: CHROME_CIPHERS,
-          minVersion: 'TLSv1.2',
-          maxVersion: 'TLSv1.3',
-          ALPNProtocols: ['h2', 'http/1.1'],
-        } as Record<string, unknown>,
-      });
+  // Write cookies to Netscape-format temp file — covers both cookieJar and flat string.
+  const cookieFilePath = join(tmpdir(), `.nblm-refresh-cookies-${process.pid}-${Date.now()}`);
+  const cookieLines = ['# Netscape HTTP Cookie File'];
+  if (session.cookieJar && session.cookieJar.length > 0) {
+    for (const c of session.cookieJar) {
+      const domainFlag = c.domain.startsWith('.') ? 'TRUE' : 'FALSE';
+      const secure = c.secure ? 'TRUE' : 'FALSE';
+      cookieLines.push(`${c.domain}\t${domainFlag}\t${c.path ?? '/'}\t${secure}\t0\t${c.name}\t${c.value}`);
+    }
+  } else {
+    for (const pair of session.cookies.split(';')) {
+      const eq = pair.indexOf('=');
+      if (eq <= 0) continue;
+      const name = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      const secure = name.startsWith('__Secure') || name.startsWith('__Host') ? 'TRUE' : 'FALSE';
+      cookieLines.push(`.google.com\tTRUE\t/\t${secure}\t0\t${name}\t${value}`);
+    }
+  }
+  writeFileSync(cookieFilePath, cookieLines.join('\n'), 'utf-8');
 
-  const { statusCode, body, headers } = await undiciRequest('https://notebooklm.google.com/', {
-    method: 'GET',
-    headers: {
-      'User-Agent': ua,
-      'Cookie': session.cookies,
-      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'Accept-Language': 'en-US,en;q=0.9',
-    },
-    dispatcher,
-  });
+  const args: string[] = [
+    '--impersonate', 'chrome136',
+    'https://notebooklm.google.com/',
+    '-s', '-S',
+    '--compressed',
+    '-D', '-',               // dump response headers to stdout before body
+    '-b', cookieFilePath,
+    '-H', `User-Agent: ${ua}`,
+    '-H', 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    '-H', 'Accept-Language: en-US,en;q=0.9',
+  ];
+  if (proxy) args.push('-x', proxy);
 
-  const html = await body.text();
+  let stdout: string;
+  try {
+    const result = await execFileAsync(binaryPath, args, { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 });
+    stdout = result.stdout;
+    if (result.stderr && result.stderr.includes('curl:')) {
+      throw new Error(`curl-impersonate: ${result.stderr.trim()}`);
+    }
+  } finally {
+    try { unlinkSync(cookieFilePath); } catch { /* ignore */ }
+  }
 
+  // Split headers (before first blank line) from body.
+  const headerBodySplit = stdout.search(/\r?\n\r?\n/);
+  const rawHeaders = headerBodySplit > 0 ? stdout.slice(0, headerBodySplit) : '';
+  const html = headerBodySplit > 0 ? stdout.slice(headerBodySplit).replace(/^\r?\n\r?\n/, '') : stdout;
+
+  const statusLine = rawHeaders.split(/\r?\n/)[0] ?? '';
+  const statusMatch = /HTTP\/[\d.]+\s+(\d{3})/.exec(statusLine);
+  const statusCode = statusMatch ? parseInt(statusMatch[1]!, 10) : 0;
   if (statusCode !== 200) {
     throw new Error(`Token refresh failed: HTTP ${statusCode}`);
+  }
+
+  // Collect Set-Cookie headers (case-insensitive, possibly multiple).
+  const setCookies: string[] = [];
+  for (const line of rawHeaders.split(/\r?\n/)) {
+    const m = /^set-cookie:\s*(.*)$/i.exec(line);
+    if (m) setCookies.push(m[1]!);
   }
 
   // Extract tokens from WIZ_global_data in the HTML
   const atMatch = /"SNlM0e":"([^"]+)"/.exec(html);
   const blMatch = /"cfb2h":"([^"]+)"/.exec(html);
   const fsidMatch = /"FdrFJe":"([^"]+)"/.exec(html);
-  // Extract language from <html lang="en"> or keep existing
   const langMatch = /<html[^>]*\slang="([^"]+)"/.exec(html);
 
   if (!atMatch?.[1]) {
     throw new Error('Token refresh failed: SNlM0e not found in page (cookies may be expired)');
   }
 
-  // Merge set-cookie headers to keep cookies fresh
-  const updatedCookies = mergeCookies(session.cookies, headers['set-cookie']);
+  const updatedCookies = mergeCookies(session.cookies, setCookies);
 
   const refreshed: NotebookRpcSession = {
     at: atMatch[1],

--- a/src/transport-curl.ts
+++ b/src/transport-curl.ts
@@ -121,6 +121,14 @@ export class CurlTransport implements Transport {
           throw new Error(`HTTP ${statusCode}: ${responseBody.slice(0, 200)}`);
         }
 
+        // Google returns HTTP 200 with an in-body gRPC-style error envelope when
+        // the session token (at/bl) is stale: ["wrb.fr","RPC_ID",null,null,null,[16],"generic"]
+        // where [16] is UNAUTHENTICATED. Detect and surface as SessionError so
+        // the transport's refresh path kicks in.
+        if (/"wrb\.fr"[^\]]*?,\s*null\s*,\s*null\s*,\s*null\s*,\s*\[\s*16\s*\]\s*,\s*"generic"/.test(responseBody)) {
+          throw new SessionError('in-body UNAUTHENTICATED (code 16)');
+        }
+
         return responseBody;
       } finally {
         try { unlinkSync(cookieFilePath); } catch { /* ignore cleanup errors */ }

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -93,7 +93,10 @@ export async function addSourceFromInput(
         console.error(`NotebookLM: Imported ${added} URL sources${report ? ' + report' : ''}`);
       }
 
-      await pollSourcesReady(client, notebookId, 120_000);
+      // Deep research imports 40+ URL sources; Google indexes each async
+      // (10-15s per URL), so 2min is too tight. Bump to 10min only here —
+      // other call sites process a single user-provided source in seconds.
+      await pollSourcesReady(client, notebookId, 600_000);
 
       const detail = await client.getNotebookDetail(notebookId);
       return detail.sources.map((s) => s.id);
@@ -110,8 +113,18 @@ export async function pollSourcesReady(
   let pollCount = 0;
   while (Date.now() - start < timeoutMs) {
     const detail = await client.getNotebookDetail(notebookId);
-    const allReady = detail.sources.length > 0 && detail.sources.every((s) => s.wordCount !== undefined && s.wordCount > 0);
-    if (allReady) return;
+    if (detail.sources.length > 0) {
+      const readyCount = detail.sources.filter(s => s.wordCount !== undefined && s.wordCount > 0).length;
+      // With 50+ URL sources from research, some will fail to fetch (403/404/timeout).
+      // Accept "mostly ready": 70% indexed or 30+ sources (whichever is lower).
+      const threshold = Math.min(Math.ceil(detail.sources.length * 0.7), 30);
+      if (readyCount >= threshold) {
+        if (readyCount < detail.sources.length) {
+          console.error(`NotebookLM: Sources ready ${readyCount}/${detail.sources.length} (threshold met)`);
+        }
+        return;
+      }
+    }
     pollCount++;
     const delay = Math.min(3000 + pollCount * 1500, 15000);
     await humanSleep(delay);
@@ -130,7 +143,15 @@ export async function pollArtifactReady(
 
   while (Date.now() - start < timeoutMs) {
     const artifacts = await client.getArtifacts(notebookId);
-    const artifact = artifacts.find((a) => a.id === artifactId);
+    let artifact = artifacts.find((a) => a.id === artifactId);
+    // Fallback: generateArtifact RPC sometimes returns a task ID that differs
+    // from the final artifact id. If exact match missed, take any ready media.
+    if (!artifact) {
+      artifact = artifacts.find(a =>
+        (a.type === ARTIFACT_TYPE.AUDIO || a.type === ARTIFACT_TYPE.VIDEO) &&
+        (a.downloadUrl || a.streamUrl || a.hlsUrl),
+      );
+    }
     if (artifact) {
       const isMedia = artifact.type === ARTIFACT_TYPE.AUDIO || artifact.type === ARTIFACT_TYPE.VIDEO;
       if (isMedia) {

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -4,21 +4,53 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { NotebookRpcSession } from '../src/types.js';
 
-// Mock undici before importing session-store
-vi.mock('undici', () => {
-  const mockRequest = vi.fn();
+// Mock curl-impersonate detection so refreshTokens always finds a "binary".
+vi.mock('../src/transport-curl.js', () => ({
+  CurlTransport: {
+    findBinary: vi.fn().mockResolvedValue('/fake/curl-impersonate'),
+  },
+}));
+
+// Mock execFile so we never actually spawn curl. The mock writes a crafted
+// "headers + blank line + body" payload that mimics `curl -D -` output.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
   return {
-    request: mockRequest,
-    Agent: vi.fn().mockImplementation(() => ({
-      close: vi.fn().mockResolvedValue(undefined),
-    })),
-    ProxyAgent: vi.fn().mockImplementation(() => ({
-      close: vi.fn().mockResolvedValue(undefined),
-    })),
+    ...actual,
+    execFile: vi.fn(),
   };
 });
 
 const { saveSession, loadSession, hasValidSession, refreshTokens } = await import('../src/session-store.js');
+const { execFile } = await import('node:child_process');
+
+type ExecFileCallback = (err: Error | null, stdout: string, stderr: string) => void;
+type CurlCall = { cmd: string; args: readonly string[] };
+
+function setCurlResponse(stdout: string, stderr = '', err: Error | null = null): void {
+  vi.mocked(execFile).mockImplementation(((cmd: string, args: readonly string[], optsOrCb: unknown, cb?: unknown) => {
+    const callback = (typeof optsOrCb === 'function' ? optsOrCb : cb) as ExecFileCallback;
+    setImmediate(() => callback(err, stdout, stderr));
+    return {} as ReturnType<typeof execFile>;
+  }) as never);
+}
+
+function captureCurlCalls(stdout: string): CurlCall[] {
+  const calls: CurlCall[] = [];
+  vi.mocked(execFile).mockImplementation(((cmd: string, args: readonly string[], optsOrCb: unknown, cb?: unknown) => {
+    calls.push({ cmd, args });
+    const callback = (typeof optsOrCb === 'function' ? optsOrCb : cb) as ExecFileCallback;
+    setImmediate(() => callback(null, stdout, ''));
+    return {} as ReturnType<typeof execFile>;
+  }) as never);
+  return calls;
+}
+
+function curlOutput(opts: { status: number; setCookies?: readonly string[]; body: string }): string {
+  const lines = [`HTTP/2 ${opts.status}`];
+  for (const c of opts.setCookies ?? []) lines.push(`set-cookie: ${c}`);
+  return `${lines.join('\r\n')}\r\n\r\n${opts.body}`;
+}
 
 function makeSession(overrides: Partial<NotebookRpcSession> = {}): NotebookRpcSession {
   return {
@@ -36,6 +68,7 @@ describe('session-store', () => {
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), 'nbsession-'));
+    vi.mocked(execFile).mockReset();
   });
 
   afterEach(async () => {
@@ -120,11 +153,11 @@ describe('session-store', () => {
       const { writeFile } = await import('node:fs/promises');
       await writeFile(filePath, JSON.stringify({
         version: 1,
-        exportedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(), // 3h ago
+        exportedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
         session: makeSession(),
       }), 'utf-8');
 
-      const valid = await hasValidSession(filePath, 2 * 60 * 60 * 1000); // 2h max
+      const valid = await hasValidSession(filePath, 2 * 60 * 60 * 1000);
       expect(valid).toBe(false);
     });
 
@@ -132,8 +165,6 @@ describe('session-store', () => {
       const filePath = join(tmpDir, 'session.json');
       await saveSession(makeSession(), filePath);
 
-      // Just saved — should be valid even with 1ms max age... almost
-      // Use a generous window
       const valid = await hasValidSession(filePath, 60_000);
       expect(valid).toBe(true);
     });
@@ -144,15 +175,11 @@ describe('session-store', () => {
       const fakeHtml = `
         <script>window.WIZ_global_data = {"SNlM0e":"new-csrf-token","cfb2h":"boq_labs-tailwind-frontend_20260316.00_p0","FdrFJe":"99999"};</script>
       `;
-
-      const { request: mockRequest } = await import('undici');
-      const mockedRequest = vi.mocked(mockRequest);
-
-      mockedRequest.mockResolvedValueOnce({
-        statusCode: 200,
-        headers: { 'set-cookie': ['NID=abc123; path=/; HttpOnly'] },
-        body: { text: vi.fn().mockResolvedValue(fakeHtml) },
-      } as never);
+      setCurlResponse(curlOutput({
+        status: 200,
+        setCookies: ['NID=abc123; path=/; HttpOnly'],
+        body: fakeHtml,
+      }));
 
       const session = makeSession();
       const savePath = join(tmpDir, 'refreshed.json');
@@ -161,26 +188,17 @@ describe('session-store', () => {
       expect(refreshed.at).toBe('new-csrf-token');
       expect(refreshed.bl).toBe('boq_labs-tailwind-frontend_20260316.00_p0');
       expect(refreshed.fsid).toBe('99999');
-      // Original cookies should be preserved, new ones merged
       expect(refreshed.cookies).toContain('SID=abc');
       expect(refreshed.cookies).toContain('NID=abc123');
       expect(refreshed.userAgent).toBe(session.userAgent);
 
-      // Should auto-save
       const saved = await loadSession(savePath);
       expect(saved).not.toBeNull();
       expect(saved!.at).toBe('new-csrf-token');
     });
 
     it('should throw when SNlM0e not found (cookies expired)', async () => {
-      const { request: mockRequest } = await import('undici');
-      const mockedRequest = vi.mocked(mockRequest);
-
-      mockedRequest.mockResolvedValueOnce({
-        statusCode: 200,
-        headers: {},
-        body: { text: vi.fn().mockResolvedValue('<html>Login page</html>') },
-      } as never);
+      setCurlResponse(curlOutput({ status: 200, body: '<html>Login page</html>' }));
 
       const session = makeSession();
       await expect(refreshTokens(session, join(tmpDir, 'fail.json')))
@@ -188,80 +206,59 @@ describe('session-store', () => {
     });
 
     it('should throw on non-200 response', async () => {
-      const { request: mockRequest } = await import('undici');
-      const mockedRequest = vi.mocked(mockRequest);
-
-      mockedRequest.mockResolvedValueOnce({
-        statusCode: 403,
-        headers: {},
-        body: { text: vi.fn().mockResolvedValue('Forbidden') },
-      } as never);
+      setCurlResponse(curlOutput({ status: 403, body: 'Forbidden' }));
 
       const session = makeSession();
       await expect(refreshTokens(session, join(tmpDir, 'fail.json')))
         .rejects.toThrow('HTTP 403');
     });
 
-    it('should use ProxyAgent when proxy is provided', async () => {
-      const fakeHtml = `"SNlM0e":"token-proxy","cfb2h":"bl-proxy","FdrFJe":"fsid-proxy"`;
+    it('should throw when curl-impersonate binary is unavailable (e.g. Windows)', async () => {
+      const { CurlTransport } = await import('../src/transport-curl.js');
+      vi.mocked(CurlTransport.findBinary).mockResolvedValueOnce(null);
 
-      const { request: mockRequest, ProxyAgent } = await import('undici');
-      const mockedRequest = vi.mocked(mockRequest);
-      const MockedProxyAgent = vi.mocked(ProxyAgent);
-
-      MockedProxyAgent.mockClear();
-
-      mockedRequest.mockResolvedValueOnce({
-        statusCode: 200,
-        headers: {},
-        body: { text: vi.fn().mockResolvedValue(fakeHtml) },
-      } as never);
-
-      const session = makeSession();
-      const refreshed = await refreshTokens(session, join(tmpDir, 'proxy.json'), 'http://127.0.0.1:7890');
-
-      expect(refreshed.at).toBe('token-proxy');
-      expect(MockedProxyAgent).toHaveBeenCalledWith(
-        expect.objectContaining({ uri: 'http://127.0.0.1:7890' }),
-      );
+      await expect(refreshTokens(makeSession(), join(tmpDir, 'noBin.json')))
+        .rejects.toThrow('curl-impersonate binary not found');
     });
 
-    it('should use regular Agent when no proxy', async () => {
+    it('should pass -x to curl when proxy is provided', async () => {
+      const fakeHtml = `"SNlM0e":"token-proxy","cfb2h":"bl-proxy","FdrFJe":"fsid-proxy"`;
+      const calls = captureCurlCalls(curlOutput({ status: 200, body: fakeHtml }));
+
+      const refreshed = await refreshTokens(
+        makeSession(),
+        join(tmpDir, 'proxy.json'),
+        'http://127.0.0.1:7890',
+      );
+
+      expect(refreshed.at).toBe('token-proxy');
+      expect(calls).toHaveLength(1);
+      const args = calls[0]!.args;
+      const xIdx = args.indexOf('-x');
+      expect(xIdx).toBeGreaterThan(-1);
+      expect(args[xIdx + 1]).toBe('http://127.0.0.1:7890');
+    });
+
+    it('should not pass -x to curl when no proxy', async () => {
       const fakeHtml = `"SNlM0e":"token-noproxy","cfb2h":"bl","FdrFJe":"fsid"`;
-
-      const { request: mockRequest, Agent: UndiciAgent } = await import('undici');
-      const mockedRequest = vi.mocked(mockRequest);
-      const MockedAgent = vi.mocked(UndiciAgent);
-
-      MockedAgent.mockClear();
-
-      mockedRequest.mockResolvedValueOnce({
-        statusCode: 200,
-        headers: {},
-        body: { text: vi.fn().mockResolvedValue(fakeHtml) },
-      } as never);
+      const calls = captureCurlCalls(curlOutput({ status: 200, body: fakeHtml }));
 
       await refreshTokens(makeSession(), join(tmpDir, 'noproxy.json'));
 
-      expect(MockedAgent).toHaveBeenCalledOnce();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.args).not.toContain('-x');
     });
 
     it('should merge Set-Cookie headers with existing cookies', async () => {
       const fakeHtml = `"SNlM0e":"token123","cfb2h":"bl-val","FdrFJe":"fsid-val"`;
-
-      const { request: mockRequest } = await import('undici');
-      const mockedRequest = vi.mocked(mockRequest);
-
-      mockedRequest.mockResolvedValueOnce({
-        statusCode: 200,
-        headers: {
-          'set-cookie': [
-            'SID=new-sid; path=/; HttpOnly',  // Should override existing SID
-            'NEW_COOKIE=xyz; path=/',
-          ],
-        },
-        body: { text: vi.fn().mockResolvedValue(fakeHtml) },
-      } as never);
+      setCurlResponse(curlOutput({
+        status: 200,
+        setCookies: [
+          'SID=new-sid; path=/; HttpOnly',
+          'NEW_COOKIE=xyz; path=/',
+        ],
+        body: fakeHtml,
+      }));
 
       const session = makeSession({ cookies: 'SID=old-sid; HSID=keep-me' });
       const refreshed = await refreshTokens(session, join(tmpDir, 'merged.json'));


### PR DESCRIPTION
## Summary

Three linked fixes that together recover the research → audio pipeline after Google tightened bot-detection behavior on NotebookLM:

- **session-store**: replace undici in \`refreshTokens()\` with the already-vendored curl-impersonate binary. Google's HTML dashboard endpoint does cookie-to-TLS-fingerprint binding (\"CookieMismatch\"), so Node/undici hits HTTP 302 regardless of cipher config.
- **transport-curl**: detect Google's in-body \`[16],\"generic\"\` envelope (HTTP 200 + gRPC UNAUTHENTICATED) and surface it as \`SessionError\` so the existing refresh branch triggers.
- **workflows**: tolerate partial source indexing (70% threshold vs. 100%), bump the research-case \`pollSourcesReady\` timeout to 10min, and fall back on any ready media artifact when \`generateArtifact\` returns a task id that doesn't match the final artifact id.

## Why

Symptoms on my side:
- \`refresh-session\` started failing with \`HTTP 302\` on sessions whose cookies were still valid.
- Long-running pipelines (LaunchAgent hourly) were hanging: \`pollSourcesReady\` / \`pollArtifactReady\` saw empty results because stale at/bl caused silent 200+empty responses that never triggered the refresh branch.
- Deep research imports 40-60 URLs; a handful always fail to fetch and stay at \`wordCount=0\`, so the \"all ready\" check could never pass in 2min.

Root cause per fix is documented in each commit message.

## Test plan

- [x] \`refresh-session\` returns 200 with SNlM0e extracted (was 302 CookieMismatch)
- [x] \`list\` reports notebooks after session ages past at/bl TTL
- [x] End-to-end: research → audio → download completes without external watchdog
- [ ] Non-research paths (single URL / file source) still work — code paths unchanged beyond the threshold helper
- [ ] Windows: curl-impersonate unavailable, \`refreshTokens\` now errors early with a clear message instead of silently failing on undici

No unit tests added — the failures are all integration-level against live Google endpoints and would need VCR-style fixtures that don't currently exist in this repo.