### PR TITLE
fix(chat): use notebook's default thread so chat messages persist in the web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ client.getTransportMode()
 
 // Notebooks
 await client.listNotebooks()                          // → NotebookInfo[]
-await client.createNotebook()                         // → { notebookId }
+await client.createNotebook()                         // → { notebookId, threadId }
 await client.getNotebookDetail(notebookId)            // → { title, sources }
 await client.deleteNotebook(notebookId)
 
@@ -280,6 +280,7 @@ await client.deleteSource(sourceId)
 
 // Chat
 await client.sendChat(notebookId, message, sourceIds) // → { text, threadId }
+await client.listChatThreads(notebookId)              // → string[] (default thread is index 0)
 await client.deleteChatThread(threadId)
 
 // Studio (dynamic — always fetch types from server)
@@ -619,7 +620,7 @@ client.getTransportMode()
 
 // 笔记本
 await client.listNotebooks()                          // → NotebookInfo[]
-await client.createNotebook()                         // → { notebookId }
+await client.createNotebook()                         // → { notebookId, threadId }
 await client.getNotebookDetail(notebookId)            // → { title, sources }
 await client.deleteNotebook(notebookId)
 
@@ -633,6 +634,7 @@ await client.deleteSource(sourceId)
 
 // 对话
 await client.sendChat(notebookId, message, sourceIds) // → { text, threadId }
+await client.listChatThreads(notebookId)              // → string[]（首条是默认 thread）
 await client.deleteChatThread(threadId)
 
 // Studio（动态 —— 始终从服务端获取类型）

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,6 +14,7 @@ import { buildArtifactPayload } from './artifact-payloads.js';
 import {
   parseCreateNotebook,
   parseListNotebooks,
+  parseListChatThreads,
   parseNotebookDetail,
   parseAddSource,
   parseGenerateArtifact,
@@ -44,13 +45,32 @@ export type { RpcCaller } from './download.js';
 
 // ── Notebooks ──
 
-export async function createNotebook(callRpc: RpcCaller): Promise<{ notebookId: string }> {
+export async function createNotebook(
+  callRpc: RpcCaller,
+): Promise<{ notebookId: string; threadId: string }> {
   const raw = await callRpc(
     NB_RPC.CREATE_NOTEBOOK,
     ['', null, null, [...PLATFORM_WEB], [1, null, null, null, null, null, null, null, null, null, [1]]],
     '/',
   );
   return parseCreateNotebook(raw);
+}
+
+/**
+ * List chat thread IDs bound to a notebook. NotebookLM auto-allocates one
+ * default thread per notebook on creation; the web UI uses that thread for
+ * every chat in the notebook so messages persist in the chat panel.
+ */
+export async function listChatThreads(
+  callRpc: RpcCaller,
+  notebookId: string,
+): Promise<string[]> {
+  const raw = await callRpc(
+    NB_RPC.LIST_CHAT_THREADS,
+    [[], null, notebookId, 20],
+    `/notebook/${notebookId}`,
+  );
+  return parseListChatThreads(raw);
 }
 
 export async function listNotebooks(callRpc: RpcCaller): Promise<NotebookInfo[]> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -93,8 +93,17 @@ export class NotebookClient {
   private proxy?: string;
   private reqCounter = 100000;
   private activeNotebookId = '';
+  /** Notebook the current chat state belongs to. State resets when this changes. */
+  private chatNotebookId = '';
+  /** ID of the chat thread used by the web UI for this notebook (from CCqFvf or hPTbtc). */
   private chatThreadId = '';
+  /**
+   * Per-thread chat history mirrored back to the server in newest-first order
+   * (matches what the web UI sends): each completed turn prepends `[assistant, user]`.
+   */
   private chatHistory: Array<[string, null, number]> = [];
+  /** Number of completed turns on the current thread (1-indexed turn counter sent in chat payload). */
+  private chatTurnCounter = 0;
 
   // ── Lifecycle ──
 
@@ -294,16 +303,22 @@ export class NotebookClient {
     const { at, bl, fsid } = this.transport.getSession();
     const reqId = this.nextReqId();
 
+    // The web UI sends `null` for the first request on a fresh session and an
+    // accumulating array thereafter. Sending `[]` instead of `null` for the
+    // first turn causes the server to accept the message but not write it to
+    // the notebook's visible chat thread on follow-ups.
+    const history = this.chatHistory.length > 0 ? this.chatHistory : null;
+
     const innerPayload = [
       sourceIdArrays,
       message,
-      this.chatHistory.length > 0 ? this.chatHistory : [],
+      history,
       [2, null, [1], [1]],
       this.chatThreadId || null,
       null,
       null,
       notebookId,
-      1,
+      this.chatTurnCounter + 1,
     ];
 
     const doCall = (): Promise<string> =>
@@ -344,10 +359,23 @@ export class NotebookClient {
 
   // ── Low-level API (delegated to api.ts) ──
 
-  async createNotebook(): Promise<{ notebookId: string }> {
+  async createNotebook(): Promise<{ notebookId: string; threadId: string }> {
     const result = await api.createNotebook(this.rpc);
     this.activeNotebookId = result.notebookId;
+    if (result.threadId) {
+      this.bindChatThread(result.notebookId, result.threadId);
+    }
     return result;
+  }
+
+  /**
+   * Lists chat thread IDs bound to a notebook. The first entry is the default
+   * thread the web UI uses, so `sendChat`/`sendChatWithCitations` resolve it
+   * automatically — call this only when you need to enumerate threads or seed
+   * a custom one.
+   */
+  async listChatThreads(notebookId: string): Promise<string[]> {
+    return api.listChatThreads(this.rpc, notebookId);
   }
 
   async listNotebooks(): Promise<NotebookInfo[]> {
@@ -502,29 +530,79 @@ export class NotebookClient {
   }
 
   async sendChat(notebookId: string, message: string, sourceIds: string[]): Promise<{ text: string; threadId: string }> {
+    await this.ensureChatThread(notebookId);
     const result = await api.sendChat(
       this.callChatStream.bind(this),
       notebookId, message, sourceIds,
     );
-    if (result.threadId) this.chatThreadId = result.threadId;
-    this.chatHistory.push([message, null, 1]);
-    if (result.text) {
-      this.chatHistory.push([result.text, null, 2]);
-    }
+    this.recordChatTurn(notebookId, message, result.text, result.threadId);
     return result;
   }
 
   async sendChatWithCitations(notebookId: string, message: string, sourceIds: string[]): Promise<ChatWithCitationsResult> {
+    await this.ensureChatThread(notebookId);
     const result = await api.sendChatWithCitations(
       this.callChatStream.bind(this),
       notebookId, message, sourceIds,
     );
-    if (result.threadId) this.chatThreadId = result.threadId;
-    this.chatHistory.push([message, null, 1]);
-    if (result.text) {
-      this.chatHistory.push([result.text, null, 2]);
-    }
+    this.recordChatTurn(notebookId, message, result.text, result.threadId);
     return result;
+  }
+
+  /**
+   * Binds local chat state to `notebookId`/`threadId` (called after createNotebook
+   * and at the start of `ensureChatThread`). Resets accumulated history and turn
+   * counter whenever the (notebookId, threadId) pair changes — the web UI's
+   * follow-up payload format requires history to start empty for a fresh thread.
+   */
+  private bindChatThread(notebookId: string, threadId: string): void {
+    if (this.chatNotebookId === notebookId && this.chatThreadId === threadId) return;
+    this.chatNotebookId = notebookId;
+    this.chatThreadId = threadId;
+    this.chatHistory = [];
+    this.chatTurnCounter = 0;
+  }
+
+  /**
+   * Resolves the notebook's default chat thread before sending a message.
+   * - If we already have a thread for this notebook, no-op.
+   * - Otherwise, fetch via `hPTbtc`. NotebookLM auto-allocates one default
+   *   thread per notebook on creation, so this should always succeed.
+   * - Empty result means the notebook is in an unusual state (no allocated
+   *   thread); we leave `chatThreadId` empty and let the chat call create one
+   *   server-side as a best-effort fallback (only the first message will be
+   *   visible in UI, follow-ups won't persist — matches pre-fix behavior).
+   */
+  private async ensureChatThread(notebookId: string): Promise<void> {
+    if (this.chatNotebookId !== notebookId) {
+      this.chatNotebookId = notebookId;
+      this.chatThreadId = '';
+      this.chatHistory = [];
+      this.chatTurnCounter = 0;
+    }
+    if (this.chatThreadId) return;
+    const threads = await api.listChatThreads(this.rpc, notebookId);
+    if (threads.length > 0 && threads[0]) {
+      this.chatThreadId = threads[0];
+    }
+  }
+
+  private recordChatTurn(
+    notebookId: string,
+    message: string,
+    replyText: string,
+    replyThreadId: string,
+  ): void {
+    // Adopt the thread the server actually wrote to in case ensureChatThread
+    // came up empty and the server allocated one for us.
+    if (replyThreadId && !this.chatThreadId) {
+      this.bindChatThread(notebookId, replyThreadId);
+    }
+    // Newest-first, with the assistant reply preceding the user prompt within
+    // each turn — this is the layout the web UI sends back on follow-ups.
+    this.chatHistory.unshift([message, null, 1]);
+    if (replyText) this.chatHistory.unshift([replyText, null, 2]);
+    this.chatTurnCounter += 1;
   }
 
   async deleteChatThread(threadId: string): Promise<void> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -74,6 +74,14 @@ import type {
 
 export type TransportMode = 'browser' | 'curl-impersonate' | 'tls-client' | 'http' | 'auto';
 
+type ChatHistoryEntry = [string, null, number];
+
+interface ChatState {
+  threadId: string;
+  history: ChatHistoryEntry[];
+  turnCounter: number;
+}
+
 export interface ConnectOptions extends BrowserLaunchOptions {
   /** Transport mode. Default: 'browser'. */
   transport?: TransportMode;
@@ -93,17 +101,8 @@ export class NotebookClient {
   private proxy?: string;
   private reqCounter = 100000;
   private activeNotebookId = '';
-  /** Notebook the current chat state belongs to. State resets when this changes. */
-  private chatNotebookId = '';
-  /** ID of the chat thread used by the web UI for this notebook (from CCqFvf or hPTbtc). */
-  private chatThreadId = '';
-  /**
-   * Per-thread chat history mirrored back to the server in newest-first order
-   * (matches what the web UI sends): each completed turn prepends `[assistant, user]`.
-   */
-  private chatHistory: Array<[string, null, number]> = [];
-  /** Number of completed turns on the current thread (1-indexed turn counter sent in chat payload). */
-  private chatTurnCounter = 0;
+  private chatStates = new Map<string, ChatState>();
+  private chatQueues = new Map<string, Promise<void>>();
 
   // ── Lifecycle ──
 
@@ -297,6 +296,15 @@ export class NotebookClient {
   }
 
   async callChatStream(notebookId: string, message: string, sourceIds: string[]): Promise<string> {
+    return this.callChatStreamWithState(this.getChatState(notebookId), notebookId, message, sourceIds);
+  }
+
+  private async callChatStreamWithState(
+    state: ChatState,
+    notebookId: string,
+    message: string,
+    sourceIds: string[],
+  ): Promise<string> {
     if (!this.transport) throw new SessionError('Not connected');
 
     const sourceIdArrays = sourceIds.map((id) => [[id]]);
@@ -307,18 +315,18 @@ export class NotebookClient {
     // accumulating array thereafter. Sending `[]` instead of `null` for the
     // first turn causes the server to accept the message but not write it to
     // the notebook's visible chat thread on follow-ups.
-    const history = this.chatHistory.length > 0 ? this.chatHistory : null;
+    const history = state.history.length > 0 ? state.history : null;
 
     const innerPayload = [
       sourceIdArrays,
       message,
       history,
       [2, null, [1], [1]],
-      this.chatThreadId || null,
+      state.threadId || null,
       null,
       null,
       notebookId,
-      this.chatTurnCounter + 1,
+      state.turnCounter + 1,
     ];
 
     const doCall = (): Promise<string> =>
@@ -530,79 +538,109 @@ export class NotebookClient {
   }
 
   async sendChat(notebookId: string, message: string, sourceIds: string[]): Promise<{ text: string; threadId: string }> {
-    await this.ensureChatThread(notebookId);
-    const result = await api.sendChat(
-      this.callChatStream.bind(this),
-      notebookId, message, sourceIds,
-    );
-    this.recordChatTurn(notebookId, message, result.text, result.threadId);
-    return result;
+    return this.enqueueChat(notebookId, async () => {
+      const state = await this.ensureChatThread(notebookId);
+      const result = await api.sendChat(
+        (id, text, sources) => this.callChatStreamWithState(state, id, text, sources),
+        notebookId, message, sourceIds,
+      );
+      this.recordChatTurn(state, message, result.text, result.threadId);
+      return result;
+    });
   }
 
   async sendChatWithCitations(notebookId: string, message: string, sourceIds: string[]): Promise<ChatWithCitationsResult> {
-    await this.ensureChatThread(notebookId);
-    const result = await api.sendChatWithCitations(
-      this.callChatStream.bind(this),
-      notebookId, message, sourceIds,
-    );
-    this.recordChatTurn(notebookId, message, result.text, result.threadId);
-    return result;
+    return this.enqueueChat(notebookId, async () => {
+      const state = await this.ensureChatThread(notebookId);
+      const result = await api.sendChatWithCitations(
+        (id, text, sources) => this.callChatStreamWithState(state, id, text, sources),
+        notebookId, message, sourceIds,
+      );
+      this.recordChatTurn(state, message, result.text, result.threadId);
+      return result;
+    });
   }
 
   /**
-   * Binds local chat state to `notebookId`/`threadId` (called after createNotebook
-   * and at the start of `ensureChatThread`). Resets accumulated history and turn
-   * counter whenever the (notebookId, threadId) pair changes — the web UI's
+   * Binds local chat state to `notebookId`/`threadId` (called after createNotebook).
+   * Resets accumulated history and turn counter whenever the thread changes — the web UI's
    * follow-up payload format requires history to start empty for a fresh thread.
    */
   private bindChatThread(notebookId: string, threadId: string): void {
-    if (this.chatNotebookId === notebookId && this.chatThreadId === threadId) return;
-    this.chatNotebookId = notebookId;
-    this.chatThreadId = threadId;
-    this.chatHistory = [];
-    this.chatTurnCounter = 0;
+    const state = this.getChatState(notebookId);
+    if (state.threadId === threadId) return;
+    state.threadId = threadId;
+    state.history = [];
+    state.turnCounter = 0;
   }
 
   /**
    * Resolves the notebook's default chat thread before sending a message.
-   * - If we already have a thread for this notebook, no-op.
+   * - If this notebook already has a thread, no-op.
    * - Otherwise, fetch via `hPTbtc`. NotebookLM auto-allocates one default
    *   thread per notebook on creation, so this should always succeed.
    * - Empty result means the notebook is in an unusual state (no allocated
-   *   thread); we leave `chatThreadId` empty and let the chat call create one
+   *   thread); we leave `threadId` empty and let the chat call create one
    *   server-side as a best-effort fallback (only the first message will be
    *   visible in UI, follow-ups won't persist — matches pre-fix behavior).
    */
-  private async ensureChatThread(notebookId: string): Promise<void> {
-    if (this.chatNotebookId !== notebookId) {
-      this.chatNotebookId = notebookId;
-      this.chatThreadId = '';
-      this.chatHistory = [];
-      this.chatTurnCounter = 0;
-    }
-    if (this.chatThreadId) return;
+  private async ensureChatThread(notebookId: string): Promise<ChatState> {
+    const state = this.getChatState(notebookId);
+    if (state.threadId) return state;
     const threads = await api.listChatThreads(this.rpc, notebookId);
-    if (threads.length > 0 && threads[0]) {
-      this.chatThreadId = threads[0];
+    if (!state.threadId && threads.length > 0 && threads[0]) {
+      state.threadId = threads[0];
     }
+    return state;
   }
 
   private recordChatTurn(
-    notebookId: string,
+    state: ChatState,
     message: string,
     replyText: string,
     replyThreadId: string,
   ): void {
     // Adopt the thread the server actually wrote to in case ensureChatThread
     // came up empty and the server allocated one for us.
-    if (replyThreadId && !this.chatThreadId) {
-      this.bindChatThread(notebookId, replyThreadId);
+    if (replyThreadId && !state.threadId) {
+      state.threadId = replyThreadId;
     }
     // Newest-first, with the assistant reply preceding the user prompt within
     // each turn — this is the layout the web UI sends back on follow-ups.
-    this.chatHistory.unshift([message, null, 1]);
-    if (replyText) this.chatHistory.unshift([replyText, null, 2]);
-    this.chatTurnCounter += 1;
+    state.history.unshift([message, null, 1]);
+    if (replyText) state.history.unshift([replyText, null, 2]);
+    state.turnCounter += 1;
+  }
+
+  private getChatState(notebookId: string): ChatState {
+    const existing = this.chatStates.get(notebookId);
+    if (existing) return existing;
+    const state: ChatState = {
+      threadId: '',
+      history: [],
+      turnCounter: 0,
+    };
+    this.chatStates.set(notebookId, state);
+    return state;
+  }
+
+  private async enqueueChat<T>(notebookId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.chatQueues.get(notebookId) ?? Promise.resolve();
+    let release: () => void = () => {};
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.chatQueues.set(notebookId, previous.then(() => current, () => current));
+
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.chatQueues.get(notebookId) === current) {
+        this.chatQueues.delete(notebookId);
+      }
+    }
   }
 
   async deleteChatThread(threadId: string): Promise<void> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -38,7 +38,7 @@ function extractAllInner(raw: string): unknown[] {
 
 // ── Notebook CRUD Parsers ──
 
-export function parseCreateNotebook(raw: string): { notebookId: string } {
+export function parseCreateNotebook(raw: string): { notebookId: string; threadId: string } {
   const inner = extractInner(raw);
   const id = getString(inner, 2);
   if (!id) {
@@ -46,7 +46,28 @@ export function parseCreateNotebook(raw: string): { notebookId: string } {
     if (raw && raw.length > 1000) debugRaw = raw.slice(0, 1000) + '...';
     throw new Error(`Failed to parse notebook ID from create response\nRaw response: ${debugRaw}`);
   }
-  return { notebookId: id };
+  // Trailing field is the auto-allocated default chat thread: [[<threadId>]].
+  // Empty string when the server omits it (treat as best-effort — caller can
+  // fall back to listChatThreads).
+  const threadId = getString(inner, 11, 0, 0);
+  return { notebookId: id, threadId };
+}
+
+/**
+ * hPTbtc response shape: `[[[<threadId>], [<threadId>], ...]]` — one tuple per
+ * chat thread bound to the notebook. Returns the IDs in server order.
+ */
+export function parseListChatThreads(raw: string): string[] {
+  const inner = extractInner(raw);
+  const entries = getArray(inner, 0);
+  if (!entries) return [];
+  const ids: string[] = [];
+  for (const entry of entries) {
+    if (Array.isArray(entry) && typeof entry[0] === 'string' && entry[0]) {
+      ids.push(entry[0]);
+    }
+  }
+  return ids;
 }
 
 export function parseListNotebooks(raw: string): NotebookInfo[] {

--- a/src/rpc-ids.ts
+++ b/src/rpc-ids.ts
@@ -43,6 +43,7 @@ export const NB_RPC = {
   DELETE_NOTE: 'AH0mwd',
 
   // ── Chat ──
+  LIST_CHAT_THREADS: 'hPTbtc',
   DELETE_CHAT_THREAD: 'J7Gthc',
 
   // ── Sharing ──

--- a/tests/chat-payload.test.ts
+++ b/tests/chat-payload.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { NotebookClient } from '../src/client.js';
+import type { Transport, TransportRequest } from '../src/transport.js';
+import type { NotebookRpcSession } from '../src/types.js';
+
+/**
+ * Mock transport that captures every outgoing request and returns canned
+ * responses keyed off the URL. The chat stream and batchexecute envelopes
+ * follow the on-the-wire `)]}'\n<len>\n<json>` format that boq-parser expects.
+ */
+class MockTransport implements Transport {
+  calls: Array<{ url: string; body: Record<string, string>; queryParams: Record<string, string> }> = [];
+  /** Threads returned by the next hPTbtc call. Defaults to one default thread. */
+  listChatThreadsResult: string[] = ['default-thread-uuid'];
+  /** threadId/responseId returned by the next chat stream call. */
+  chatStreamThreadId = 'default-thread-uuid';
+  chatStreamResponseId = 'resp-id';
+  chatStreamText = 'mock reply';
+
+  async execute(req: TransportRequest): Promise<string> {
+    this.calls.push({ url: req.url, body: { ...req.body }, queryParams: { ...req.queryParams } });
+
+    if (req.url.endsWith('/GenerateFreeFormStreamed')) {
+      return this.buildChatResponse();
+    }
+    if (req.url.endsWith('/batchexecute')) {
+      const rpcid = req.queryParams['rpcids'] ?? new URL(req.url + '?' + new URLSearchParams(req.queryParams).toString()).searchParams.get('rpcids');
+      if (rpcid === 'hPTbtc') return this.buildListThreadsResponse();
+      throw new Error(`MockTransport: unexpected rpcid ${rpcid}`);
+    }
+    throw new Error(`MockTransport: unexpected URL ${req.url}`);
+  }
+
+  getSession(): NotebookRpcSession {
+    return {
+      cookies: [],
+      at: 'mock-at',
+      bl: 'mock-bl',
+      fsid: 'mock-fsid',
+      language: 'en',
+      lastUpdated: 0,
+    } as NotebookRpcSession;
+  }
+
+  async refreshSession(): Promise<void> {}
+  async dispose(): Promise<void> {}
+
+  /** Decode the chat stream request the SUT just sent and return its inner payload. */
+  lastChatPayload(): unknown[] {
+    const last = [...this.calls].reverse().find((c) => c.url.endsWith('/GenerateFreeFormStreamed'));
+    if (!last) throw new Error('no chat stream call captured');
+    const fReq = last.body['f.req'];
+    if (!fReq) throw new Error('no f.req in chat body');
+    const outer = JSON.parse(fReq) as [null, string];
+    return JSON.parse(outer[1]) as unknown[];
+  }
+
+  private buildChatResponse(): string {
+    // Inner payload echoes [text, null, [threadId, responseId, ...]] per parser.parseChatStream.
+    const inner = [this.chatStreamText, null, [this.chatStreamThreadId, this.chatStreamResponseId, 0]];
+    const env = [['wrb.fr', 'oid', JSON.stringify(inner), null]];
+    const json = JSON.stringify(env);
+    return `)]}'\n${json.length}\n${json}`;
+  }
+
+  private buildListThreadsResponse(): string {
+    // hPTbtc shape: [[[threadId], [threadId], ...]]
+    const inner = [this.listChatThreadsResult.map((id) => [id])];
+    const env = [['wrb.fr', 'hPTbtc', JSON.stringify(inner), null]];
+    const json = JSON.stringify(env);
+    return `)]}'\n${json.length}\n${json}`;
+  }
+}
+
+function makeClient(mock: MockTransport): NotebookClient {
+  const c = new NotebookClient();
+  // Bypass connect() — we don't need a real transport, just inject the mock.
+  (c as unknown as { transport: Transport; transportMode: string }).transport = mock;
+  (c as unknown as { transport: Transport; transportMode: string }).transportMode = 'http';
+  return c;
+}
+
+const NOTEBOOK_A = '11111111-1111-1111-1111-111111111111';
+const NOTEBOOK_B = '22222222-2222-2222-2222-222222222222';
+
+describe('chat payload — single notebook, multi-turn', () => {
+  it('first turn sends chatHistory=null and turn counter=1', async () => {
+    const mock = new MockTransport();
+    const c = makeClient(mock);
+
+    await c.sendChat(NOTEBOOK_A, 'first question', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[2]).toBeNull();             // chatHistory MUST be null on first call
+    expect(payload[4]).toBe('default-thread-uuid'); // threadId resolved via hPTbtc
+    expect(payload[7]).toBe(NOTEBOOK_A);
+    expect(payload[8]).toBe(1);                // turn counter
+  });
+
+  it('second turn sends accumulated history (newest-first, assistant before user) and turn=2', async () => {
+    const mock = new MockTransport();
+    mock.chatStreamText = 'first reply';
+    const c = makeClient(mock);
+
+    await c.sendChat(NOTEBOOK_A, 'first question', ['src-1']);
+
+    mock.chatStreamText = 'second reply';
+    await c.sendChat(NOTEBOOK_A, 'second question', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[2]).toEqual([
+      ['first reply', null, 2],
+      ['first question', null, 1],
+    ]);
+    expect(payload[4]).toBe('default-thread-uuid');
+    expect(payload[8]).toBe(2);
+  });
+
+  it('third turn keeps newest-first ordering and turn=3', async () => {
+    const mock = new MockTransport();
+    const c = makeClient(mock);
+
+    mock.chatStreamText = 'A1';
+    await c.sendChat(NOTEBOOK_A, 'Q1', ['src-1']);
+    mock.chatStreamText = 'A2';
+    await c.sendChat(NOTEBOOK_A, 'Q2', ['src-1']);
+    mock.chatStreamText = 'A3';
+    await c.sendChat(NOTEBOOK_A, 'Q3', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[2]).toEqual([
+      ['A2', null, 2],
+      ['Q2', null, 1],
+      ['A1', null, 2],
+      ['Q1', null, 1],
+    ]);
+    expect(payload[8]).toBe(3);
+  });
+
+  it('skips assistant entry if reply text is empty (only user message recorded)', async () => {
+    const mock = new MockTransport();
+    mock.chatStreamText = '';
+    const c = makeClient(mock);
+
+    await c.sendChat(NOTEBOOK_A, 'Q1', ['src-1']);
+    mock.chatStreamText = 'A2';
+    await c.sendChat(NOTEBOOK_A, 'Q2', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[2]).toEqual([
+      ['Q1', null, 1],
+    ]);
+    expect(payload[8]).toBe(2);
+  });
+});
+
+describe('chat payload — thread resolution', () => {
+  it('calls hPTbtc once per notebook to resolve the default thread', async () => {
+    const mock = new MockTransport();
+    const c = makeClient(mock);
+
+    await c.sendChat(NOTEBOOK_A, 'Q1', ['src-1']);
+    await c.sendChat(NOTEBOOK_A, 'Q2', ['src-1']);
+    await c.sendChat(NOTEBOOK_A, 'Q3', ['src-1']);
+
+    const listThreadsCalls = mock.calls.filter(
+      (c) => c.url.endsWith('/batchexecute') && c.queryParams['rpcids'] === 'hPTbtc',
+    );
+    expect(listThreadsCalls).toHaveLength(1);
+  });
+
+  it('resets state when notebookId changes (different threads, fresh history)', async () => {
+    const mock = new MockTransport();
+    const c = makeClient(mock);
+
+    mock.chatStreamText = 'A-reply';
+    mock.chatStreamThreadId = 'thread-A';
+    mock.listChatThreadsResult = ['thread-A'];
+    await c.sendChat(NOTEBOOK_A, 'Q-on-A', ['src-1']);
+
+    mock.chatStreamText = 'B-reply';
+    mock.chatStreamThreadId = 'thread-B';
+    mock.listChatThreadsResult = ['thread-B'];
+    await c.sendChat(NOTEBOOK_B, 'Q-on-B', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[2]).toBeNull();          // history reset
+    expect(payload[4]).toBe('thread-B');
+    expect(payload[7]).toBe(NOTEBOOK_B);
+    expect(payload[8]).toBe(1);             // counter reset
+  });
+
+  it('falls back to threadId=null when hPTbtc returns no threads', async () => {
+    const mock = new MockTransport();
+    mock.listChatThreadsResult = [];
+    mock.chatStreamThreadId = 'server-allocated';
+    const c = makeClient(mock);
+
+    await c.sendChat(NOTEBOOK_A, 'Q1', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[4]).toBeNull();          // no thread to send
+
+    // Subsequent call adopts the server-allocated thread from the reply.
+    await c.sendChat(NOTEBOOK_A, 'Q2', ['src-1']);
+    const payload2 = mock.lastChatPayload();
+    expect(payload2[4]).toBe('server-allocated');
+  });
+});
+
+describe('chat payload — sourceIds and config', () => {
+  it('wraps each sourceId in [[<id>]] and preserves the config tuple', async () => {
+    const mock = new MockTransport();
+    const c = makeClient(mock);
+
+    await c.sendChat(NOTEBOOK_A, 'Q', ['s1', 's2']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[0]).toEqual([[['s1']], [['s2']]]);
+    expect(payload[3]).toEqual([2, null, [1], [1]]);
+  });
+});

--- a/tests/chat-payload.test.ts
+++ b/tests/chat-payload.test.ts
@@ -190,6 +190,144 @@ describe('chat payload — thread resolution', () => {
     expect(payload[8]).toBe(1);             // counter reset
   });
 
+  it('preserves each notebook history when switching A -> B -> A', async () => {
+    const mock = new MockTransport();
+    const c = makeClient(mock);
+
+    mock.chatStreamText = 'A1';
+    mock.chatStreamThreadId = 'thread-A';
+    mock.listChatThreadsResult = ['thread-A'];
+    await c.sendChat(NOTEBOOK_A, 'Q1-A', ['src-1']);
+
+    mock.chatStreamText = 'B1';
+    mock.chatStreamThreadId = 'thread-B';
+    mock.listChatThreadsResult = ['thread-B'];
+    await c.sendChat(NOTEBOOK_B, 'Q1-B', ['src-1']);
+
+    mock.chatStreamText = 'A2';
+    mock.chatStreamThreadId = 'thread-A';
+    mock.listChatThreadsResult = ['thread-A'];
+    await c.sendChat(NOTEBOOK_A, 'Q2-A', ['src-1']);
+
+    const payload = mock.lastChatPayload();
+    expect(payload[2]).toEqual([
+      ['A1', null, 2],
+      ['Q1-A', null, 1],
+    ]);
+    expect(payload[4]).toBe('thread-A');
+    expect(payload[7]).toBe(NOTEBOOK_A);
+    expect(payload[8]).toBe(2);
+  });
+
+  it('keeps concurrent chats for different notebooks isolated', async () => {
+    class DeferredMockTransport extends MockTransport {
+      private chatReplies = new Map<string, { text: string; threadId: string }>([
+        [NOTEBOOK_A, { text: 'A1', threadId: 'thread-A' }],
+        [NOTEBOOK_B, { text: 'B1', threadId: 'thread-B' }],
+      ]);
+      private listThreads = new Map<string, string[]>([
+        [NOTEBOOK_A, ['thread-A']],
+        [NOTEBOOK_B, ['thread-B']],
+      ]);
+      private waiters = new Map<string, () => void>();
+
+      async execute(req: TransportRequest): Promise<string> {
+        this.calls.push({ url: req.url, body: { ...req.body }, queryParams: { ...req.queryParams } });
+
+        if (req.url.endsWith('/GenerateFreeFormStreamed')) {
+          const payload = this.payloadFromRequest(req);
+          const notebookId = String(payload[7]);
+          await new Promise<void>((resolve) => {
+            this.waiters.set(notebookId, resolve);
+          });
+          const reply = this.chatReplies.get(notebookId);
+          if (!reply) throw new Error(`no chat reply for ${notebookId}`);
+          return this.buildChatResponse(reply.text, reply.threadId);
+        }
+
+        if (req.url.endsWith('/batchexecute')) {
+          const rpcid = req.queryParams['rpcids'];
+          if (rpcid !== 'hPTbtc') throw new Error(`unexpected rpcid ${rpcid}`);
+          const fReq = req.body['f.req'];
+          if (!fReq) throw new Error('no f.req in list threads body');
+          const outer = JSON.parse(fReq) as [[[string, string, null, string]]];
+          const payload = JSON.parse(outer[0][0][1]) as unknown[];
+          const notebookId = String(payload[2]);
+          return this.buildListThreadsResponse(this.listThreads.get(notebookId) ?? []);
+        }
+
+        throw new Error(`unexpected URL ${req.url}`);
+      }
+
+      releaseChat(notebookId: string): void {
+        const resolve = this.waiters.get(notebookId);
+        if (!resolve) throw new Error(`no pending chat for ${notebookId}`);
+        this.waiters.delete(notebookId);
+        resolve();
+      }
+
+      async waitForPendingChat(notebookId: string): Promise<void> {
+        for (let i = 0; i < 20; i++) {
+          if (this.waiters.has(notebookId)) return;
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        throw new Error(`chat did not start for ${notebookId}`);
+      }
+
+      chatPayloads(): unknown[][] {
+        return this.calls
+          .filter((c) => c.url.endsWith('/GenerateFreeFormStreamed'))
+          .map((c) => this.payloadFromBody(c.body));
+      }
+
+      private payloadFromRequest(req: TransportRequest): unknown[] {
+        return this.payloadFromBody(req.body);
+      }
+
+      private payloadFromBody(body: Record<string, string>): unknown[] {
+        const fReq = body['f.req'];
+        if (!fReq) throw new Error('no f.req in chat body');
+        const outer = JSON.parse(fReq) as [null, string];
+        return JSON.parse(outer[1]) as unknown[];
+      }
+
+      private buildChatResponse(text: string, threadId: string): string {
+        const inner = [text, null, [threadId, 'resp-id', 0]];
+        const env = [['wrb.fr', 'oid', JSON.stringify(inner), null]];
+        const json = JSON.stringify(env);
+        return `)]}'\n${json.length}\n${json}`;
+      }
+
+      private buildListThreadsResponse(threadIds: string[]): string {
+        const inner = [threadIds.map((id) => [id])];
+        const env = [['wrb.fr', 'hPTbtc', JSON.stringify(inner), null]];
+        const json = JSON.stringify(env);
+        return `)]}'\n${json.length}\n${json}`;
+      }
+    }
+
+    const mock = new DeferredMockTransport();
+    const c = makeClient(mock);
+
+    const chatA = c.sendChat(NOTEBOOK_A, 'Q1-A', ['src-1']);
+    const chatB = c.sendChat(NOTEBOOK_B, 'Q1-B', ['src-1']);
+
+    await Promise.all([
+      mock.waitForPendingChat(NOTEBOOK_A),
+      mock.waitForPendingChat(NOTEBOOK_B),
+    ]);
+    mock.releaseChat(NOTEBOOK_B);
+    mock.releaseChat(NOTEBOOK_A);
+    await Promise.all([chatA, chatB]);
+
+    const payloads = mock.chatPayloads();
+    const byNotebook = new Map(payloads.map((payload) => [payload[7], payload]));
+    expect(byNotebook.get(NOTEBOOK_A)?.[4]).toBe('thread-A');
+    expect(byNotebook.get(NOTEBOOK_B)?.[4]).toBe('thread-B');
+    expect(byNotebook.get(NOTEBOOK_A)?.[2]).toBeNull();
+    expect(byNotebook.get(NOTEBOOK_B)?.[2]).toBeNull();
+  });
+
   it('falls back to threadId=null when hPTbtc returns no threads', async () => {
     const mock = new MockTransport();
     mock.listChatThreadsResult = [];

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   parseCreateNotebook,
   parseListNotebooks,
+  parseListChatThreads,
   parseNotebookDetail,
   parseAddSource,
   parseGenerateArtifact,
@@ -25,9 +26,60 @@ describe('parseCreateNotebook', () => {
     expect(result.notebookId).toBe('abc-def-123');
   });
 
+  it('extracts the auto-allocated default chat thread from position [11][0][0]', () => {
+    // Mirrors a real CCqFvf response: notebookId at [2], thread tuple at [11].
+    const raw = wrapEnvelope('CCqFvf', [
+      '', null, 'nb-uuid', null, null,
+      [1, false, true, null, null, null, 1, null, null, null, null, null, false],
+      null, null, null, null, null,
+      [['thread-uuid-aaaa']],
+    ]);
+    const result = parseCreateNotebook(raw);
+    expect(result.notebookId).toBe('nb-uuid');
+    expect(result.threadId).toBe('thread-uuid-aaaa');
+  });
+
+  it('returns empty threadId when the trailing tuple is missing (legacy/older response)', () => {
+    const raw = wrapEnvelope('CCqFvf', ['', null, 'nb-uuid']);
+    const result = parseCreateNotebook(raw);
+    expect(result.notebookId).toBe('nb-uuid');
+    expect(result.threadId).toBe('');
+  });
+
   it('throws on missing ID', () => {
     const raw = wrapEnvelope('CCqFvf', ['', null, '']);
     expect(() => parseCreateNotebook(raw)).toThrow('Failed to parse notebook ID');
+  });
+});
+
+describe('parseListChatThreads', () => {
+  it('extracts thread IDs from [[[id1], [id2], ...]]', () => {
+    const raw = wrapEnvelope('hPTbtc', [
+      [['thread-1'], ['thread-2'], ['thread-3']],
+    ]);
+    expect(parseListChatThreads(raw)).toEqual(['thread-1', 'thread-2', 'thread-3']);
+  });
+
+  it('returns single thread for the typical default-only notebook', () => {
+    const raw = wrapEnvelope('hPTbtc', [[['only-thread']]]);
+    expect(parseListChatThreads(raw)).toEqual(['only-thread']);
+  });
+
+  it('returns empty array when the notebook has no threads', () => {
+    const raw = wrapEnvelope('hPTbtc', [[]]);
+    expect(parseListChatThreads(raw)).toEqual([]);
+  });
+
+  it('skips entries without a string thread ID', () => {
+    const raw = wrapEnvelope('hPTbtc', [
+      [['thread-1'], [null], [], ['thread-2']],
+    ]);
+    expect(parseListChatThreads(raw)).toEqual(['thread-1', 'thread-2']);
+  });
+
+  it('returns empty for malformed envelope', () => {
+    const raw = wrapEnvelope('hPTbtc', null);
+    expect(parseListChatThreads(raw)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Library-issued chats only render their first message in the NotebookLM web UI; follow-ups within the same `NotebookClient` session are accepted by the server but disappear from the chat panel. The fix routes chat through the auto-allocated default thread that the web UI itself uses.

- **`parseCreateNotebook`**: extract the threadId returned at position `[11][0][0]` of the `CCqFvf` response (previously discarded). `createNotebook()` now returns `{ notebookId, threadId }` (additive — destructuring `{ notebookId }` still works).
- **New `LIST_CHAT_THREADS = 'hPTbtc'` RPC**: `client.listChatThreads(notebookId)` returns the thread IDs bound to a notebook (default thread is index 0). Used internally to recover the threadId for notebooks the client didn't create itself.
- **Chat payload realigned with the web UI** (`callChatStream`):
  - `chatHistory` is `null` on the first turn instead of `[]` (server treats `[]` follow-ups as out-of-thread and skips persistence).
  - History is accumulated newest-first with the assistant reply preceding the user prompt within each turn — matches what the UI sends.
  - The trailing turn counter at `[8]` is now `chatTurnCounter + 1` instead of a hardcoded `1`.
- **Per-notebook chat state machine**: `bindChatThread` / `ensureChatThread` / `recordChatTurn` reset history, turn counter, and threadId when the active notebook changes, so the same `NotebookClient` instance can switch between notebooks without leaking state.

## Why

Captured the working web-UI request via Proxyman on \`notebooklm.google.com\` and diffed against what \`callChatStream\` sent:

| Field | Web UI | Pre-fix |
|-------|--------|---------|
| \`inner[2]\` (chatHistory) on first turn | \`null\` | \`[]\` |
| \`inner[2]\` order | newest-first, \`[assistant, user]\` per turn | oldest-first, \`[user, assistant]\` per turn |
| \`inner[4]\` (threadId) | \`<default thread from CCqFvf>\`, set on every request | \`null\` first call, then server-allocated orphan |
| \`inner[8]\` (turn counter) | increments per completed turn | always \`1\` |

The CLI never tripped the bug because each \`npx notebooklm chat ...\` is a fresh process — \`chatThreadId\` is always empty, so every chat takes the "first message of a new thread" path that NotebookLM does persist for one message. Long-lived clients (e.g. an MCP server reusing a singleton \`NotebookClient\`) hit the broken follow-up path on the second call.

The threadId field at position \`[11]\` of the \`CCqFvf\` response is what the web UI reads as its default chat thread; without it, library-issued chats land in "orphan" threads that aren't enumerated by \`hPTbtc\` and are therefore invisible to the chat panel.

## Test plan

- [x] 6 new \`parseCreateNotebook\` / \`parseListChatThreads\` parser unit tests (real-shape fixtures + edge cases)
- [x] 8 new \`tests/chat-payload.test.ts\` mock-transport tests covering: first-turn \`null\` history, newest-first accumulation, turn counter, sourceId wrapping, single-call hPTbtc resolution, notebook-switch state reset, server-allocated-threadId fallback
- [x] All 167 unit tests pass (was 152 before the PR)
- [x] Live end-to-end smoke against \`notebooklm.google.com\`: 3 consecutive \`sendChatWithCitations\` on an existing notebook all land in the same default thread and render in the web UI chat panel
- [x] Backward compatibility: \`const { notebookId } = await client.createNotebook()\` still compiles (return type widened, not narrowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)