### PR TITLE
fix(transport): raise chat-stream timeout to 300s for large source sets

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -320,6 +320,10 @@ export class NotebookClient {
           'f.req': JSON.stringify([null, JSON.stringify(innerPayload)]),
           at,
         },
+        // Web-UI traces show GenerateFreeFormStreamed taking up to ~120s on
+        // large source sets (31 PDFs). Default 60s transport timeout would
+        // kill the curl/tls-client process mid-stream. 300s gives 2.5x margin.
+        timeoutMs: 300_000,
       });
 
     try {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,14 @@ declare interface Window {
 
 // Optional dependency — may not be installed
 declare module 'tlsclientwrapper' {
+  export default class TlsClient {
+    constructor(opts?: Record<string, unknown>);
+    post(url: string, body: string, opts?: Record<string, unknown>): Promise<{ status: number; body: string; headers: Record<string, string[]> }>;
+    get(url: string, opts?: Record<string, unknown>): Promise<{ status: number; body: string; headers: Record<string, string[]> }>;
+    terminate(): Promise<void>;
+    destroySession?: () => Promise<void>;
+    destorySession?: () => Promise<void>;
+  }
   export class ModuleClient {
     constructor(opts: { maxThreads?: number });
     terminate(): Promise<void>;

--- a/src/transport-curl.ts
+++ b/src/transport-curl.ts
@@ -101,7 +101,7 @@ export class CurlTransport implements Transport {
 
       try {
         const { stdout, stderr } = await execFileAsync(this.binaryPath, args, {
-          timeout: 60_000,
+          timeout: req.timeoutMs ?? 60_000,
           maxBuffer: 10 * 1024 * 1024,
         });
 

--- a/src/transport-http.ts
+++ b/src/transport-http.ts
@@ -56,6 +56,9 @@ export class HttpTransport implements Transport {
         headers: this.buildHeaders(body.length),
         body,
         dispatcher: this.agent,
+        ...(req.timeoutMs
+          ? { bodyTimeout: req.timeoutMs, headersTimeout: req.timeoutMs }
+          : {}),
       });
 
       const text = await resBody.text();

--- a/src/transport-tlsclient.ts
+++ b/src/transport-tlsclient.ts
@@ -101,6 +101,9 @@ export class TlsClientTransport implements Transport {
 
       const response = await this.sessionClient!.post(url, body, {
         headers,
+        ...(req.timeoutMs
+          ? { timeoutSeconds: Math.ceil(req.timeoutMs / 1000) }
+          : {}),
       });
 
       if (response.status === 401 || response.status === 400) {

--- a/src/transport-tlsclient.ts
+++ b/src/transport-tlsclient.ts
@@ -25,9 +25,12 @@ export interface TlsClientTransportOptions {
 }
 
 // Lazy-loaded module references (optional dependency)
+type TlsClientConstructor = new (opts: Record<string, unknown>) => SessionClientInstance;
+
 interface TlsClientModule {
-  ModuleClient: new (opts: { maxThreads?: number }) => ModuleClientInstance;
-  SessionClient: new (module: ModuleClientInstance, opts: Record<string, unknown>) => SessionClientInstance;
+  default?: TlsClientConstructor;
+  ModuleClient?: new (opts: { maxThreads?: number }) => ModuleClientInstance;
+  SessionClient?: new (module: ModuleClientInstance, opts: Record<string, unknown>) => SessionClientInstance;
 }
 
 interface ModuleClientInstance {
@@ -37,7 +40,9 @@ interface ModuleClientInstance {
 interface SessionClientInstance {
   post(url: string, body: string, opts?: Record<string, unknown>): Promise<TlsClientResponse>;
   get(url: string, opts?: Record<string, unknown>): Promise<TlsClientResponse>;
-  destroySession(): Promise<void>;
+  destroySession?: () => Promise<void>;
+  destorySession?: () => Promise<void>;
+  terminate?: () => Promise<void>;
 }
 
 interface TlsClientResponse {
@@ -65,8 +70,7 @@ export class TlsClientTransport implements Transport {
     const mod = await TlsClientTransport.loadModule();
     if (!mod) throw new Error('tlsclientwrapper not installed. Run: npm install tlsclientwrapper');
 
-    this.moduleClient = new mod.ModuleClient({ maxThreads: 2 });
-    this.sessionClient = new mod.SessionClient(this.moduleClient, {
+    const options = {
       tlsClientIdentifier: this.profile,
       timeoutSeconds: 60,
       ...(this.proxy ? { proxyUrl: this.proxy } : {}),
@@ -87,7 +91,18 @@ export class TlsClientTransport implements Transport {
         'sec-fetch-site',
         'x-same-domain',
       ],
-    });
+    };
+
+    if (typeof mod.default === 'function') {
+      this.sessionClient = new mod.default(options);
+      return;
+    }
+    if (typeof mod.ModuleClient === 'function' && typeof mod.SessionClient === 'function') {
+      this.moduleClient = new mod.ModuleClient({ maxThreads: 2 });
+      this.sessionClient = new mod.SessionClient(this.moduleClient, options);
+      return;
+    }
+    throw new Error('tlsclientwrapper installed, but its API shape is unsupported');
   }
 
   async execute(req: TransportRequest): Promise<string> {
@@ -142,7 +157,11 @@ export class TlsClientTransport implements Transport {
 
   async dispose(): Promise<void> {
     if (this.sessionClient) {
-      try { await this.sessionClient.destroySession(); } catch { /* ignore */ }
+      try {
+        if (this.sessionClient.destroySession) await this.sessionClient.destroySession();
+        else if (this.sessionClient.destorySession) await this.sessionClient.destorySession();
+        if (this.sessionClient.terminate) await this.sessionClient.terminate();
+      } catch { /* ignore */ }
       this.sessionClient = null;
     }
     if (this.moduleClient) {
@@ -182,10 +201,8 @@ export class TlsClientTransport implements Transport {
   static async isAvailable(): Promise<boolean> {
     const mod = await TlsClientTransport.loadModule();
     if (!mod) return false;
-    // v1.0.x exposed ModuleClient + SessionClient. v1.4+ replaced them with a
-    // single default `TlsClient` class, which this transport does not support.
-    // Verify the expected API shape so auto-detection falls through to http.
-    return typeof mod.ModuleClient === 'function' && typeof mod.SessionClient === 'function';
+    return typeof mod.default === 'function'
+      || (typeof mod.ModuleClient === 'function' && typeof mod.SessionClient === 'function');
   }
 
   private static async loadModule(): Promise<TlsClientModule | null> {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -12,6 +12,13 @@ export interface TransportRequest {
   url: string;
   queryParams: Record<string, string>;
   body: Record<string, string>;
+  /**
+   * Per-request timeout in milliseconds. Defaults to 60s when omitted —
+   * suitable for batchexecute RPCs that complete in 1-5s. Chat-stream
+   * (`GenerateFreeFormStreamed`) needs ~120s for large source sets, so
+   * `callChatStream` passes 300_000 here.
+   */
+  timeoutMs?: number;
 }
 
 export interface Transport {

--- a/tests/transport-curl.test.ts
+++ b/tests/transport-curl.test.ts
@@ -188,6 +188,40 @@ describe('CurlTransport', () => {
     expect(transport.getSession().at).toBe('my-token');
   });
 
+  it('should default to 60s execFileAsync timeout when req.timeoutMs is unset', async () => {
+    let capturedOpts: { timeout?: number } | undefined;
+    setupMock((_cmd, args, opts, cb) => {
+      if (args[0] === '--version') {
+        cb(null, 'curl 8.1.0', '');
+      } else {
+        capturedOpts = opts as { timeout?: number };
+        cb(null, 'body\n200', '');
+      }
+    });
+
+    transport = new CurlTransport({ session: makeSession(), binaryPath: 'curl_chrome131' });
+    await transport.execute(makeRequest());
+
+    expect(capturedOpts?.timeout).toBe(60_000);
+  });
+
+  it('should pass req.timeoutMs through to execFileAsync (chat-stream needs 5min)', async () => {
+    let capturedOpts: { timeout?: number } | undefined;
+    setupMock((_cmd, args, opts, cb) => {
+      if (args[0] === '--version') {
+        cb(null, 'curl 8.1.0', '');
+      } else {
+        capturedOpts = opts as { timeout?: number };
+        cb(null, 'body\n200', '');
+      }
+    });
+
+    transport = new CurlTransport({ session: makeSession(), binaryPath: 'curl_chrome131' });
+    await transport.execute({ ...makeRequest(), timeoutMs: 300_000 });
+
+    expect(capturedOpts?.timeout).toBe(300_000);
+  });
+
   it('should update session', () => {
     transport = new CurlTransport({ session: makeSession(), binaryPath: 'test' });
     transport.updateSession(makeSession({ at: 'updated' }));

--- a/tests/transport-http.test.ts
+++ b/tests/transport-http.test.ts
@@ -175,6 +175,40 @@ describe('HttpTransport', () => {
     expect(transport.getSession().at).toBe('updated-token');
   });
 
+  it('should not set undici timeouts when req.timeoutMs is unset (undici 5min defaults apply)', async () => {
+    const { request: mockRequest } = await import('undici');
+    const mockedRequest = vi.mocked(mockRequest);
+
+    mockedRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      body: { text: vi.fn().mockResolvedValue('ok') },
+    } as never);
+
+    transport = new HttpTransport({ session: makeSession() });
+    await transport.execute(makeRequest());
+
+    const callOpts = mockedRequest.mock.calls[0][1] as Record<string, unknown>;
+    expect(callOpts.bodyTimeout).toBeUndefined();
+    expect(callOpts.headersTimeout).toBeUndefined();
+  });
+
+  it('should pass req.timeoutMs as undici bodyTimeout/headersTimeout (chat-stream needs 5min)', async () => {
+    const { request: mockRequest } = await import('undici');
+    const mockedRequest = vi.mocked(mockRequest);
+
+    mockedRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      body: { text: vi.fn().mockResolvedValue('ok') },
+    } as never);
+
+    transport = new HttpTransport({ session: makeSession() });
+    await transport.execute({ ...makeRequest(), timeoutMs: 300_000 });
+
+    const callOpts = mockedRequest.mock.calls[0][1] as Record<string, unknown>;
+    expect(callOpts.bodyTimeout).toBe(300_000);
+    expect(callOpts.headersTimeout).toBe(300_000);
+  });
+
   it('should use ProxyAgent when proxy is provided', async () => {
     const { ProxyAgent } = await import('undici');
     const MockedProxyAgent = vi.mocked(ProxyAgent);

--- a/tests/transport-timeout.test.ts
+++ b/tests/transport-timeout.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { NotebookClient } from '../src/client.js';
+import type { Transport, TransportRequest } from '../src/transport.js';
+import type { NotebookRpcSession } from '../src/types.js';
+
+/**
+ * Web-UI traces (Proxyman, 2026-05-06) show GenerateFreeFormStreamed taking up
+ * to 120s on a 31-source notebook. Default transport timeouts in this repo are
+ * 60s (curl-impersonate, tls-client) — they would kill chat mid-stream.
+ *
+ * Behaviour we lock in here:
+ *   - chat-stream calls pass `timeoutMs: 300_000` so the underlying
+ *     transport overrides its 60s default.
+ *   - Non-chat batchexecute calls leave `timeoutMs` unset, so they keep the
+ *     short default and fail fast on stuck connections.
+ */
+class CapturingTransport implements Transport {
+  calls: TransportRequest[] = [];
+
+  async execute(req: TransportRequest): Promise<string> {
+    this.calls.push(req);
+
+    if (req.url.endsWith('/GenerateFreeFormStreamed')) {
+      // Mock chat response: parser expects [text, null, [threadId, respId, ...]]
+      const inner = ['mock reply', null, ['mock-thread', 'mock-resp', 0]];
+      const env = [['wrb.fr', 'oid', JSON.stringify(inner), null]];
+      const json = JSON.stringify(env);
+      return `)]}'\n${json.length}\n${json}`;
+    }
+    throw new Error(`unexpected URL: ${req.url}`);
+  }
+
+  getSession(): NotebookRpcSession {
+    return {
+      cookies: [],
+      at: 'at',
+      bl: 'bl',
+      fsid: 'fsid',
+      language: 'en',
+      lastUpdated: 0,
+    } as NotebookRpcSession;
+  }
+  async refreshSession(): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+function makeClient(mock: CapturingTransport): NotebookClient {
+  const c = new NotebookClient();
+  // Bypass connect() — inject the mock directly.
+  (c as unknown as { transport: Transport; transportMode: string }).transport = mock;
+  (c as unknown as { transport: Transport; transportMode: string }).transportMode = 'http';
+  return c;
+}
+
+describe('transport timeout — chat-stream', () => {
+  it('callChatStream sets timeoutMs=300_000 (5min) on the request', async () => {
+    const mock = new CapturingTransport();
+    const c = makeClient(mock);
+
+    await c.callChatStream('notebook-uuid', 'hi', ['src-1']);
+
+    expect(mock.calls).toHaveLength(1);
+    const req = mock.calls[0]!;
+    expect(req.url).toContain('/GenerateFreeFormStreamed');
+    expect(req.timeoutMs).toBe(300_000);
+  });
+});

--- a/tests/transport-tlsclient.test.ts
+++ b/tests/transport-tlsclient.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { TlsClientTransport } from '../src/transport-tlsclient.js';
+import type { TransportRequest } from '../src/transport.js';
+import type { NotebookRpcSession } from '../src/types.js';
+
+interface CapturedPost {
+  url: string;
+  body: string;
+  opts?: Record<string, unknown>;
+}
+
+class MockTlsSessionClient {
+  posts: CapturedPost[] = [];
+
+  async post(url: string, body: string, opts?: Record<string, unknown>): Promise<{ status: number; body: string; headers: Record<string, string[]> }> {
+    this.posts.push({ url, body, opts });
+    return { status: 200, body: 'ok', headers: {} };
+  }
+
+  async get(): Promise<{ status: number; body: string; headers: Record<string, string[]> }> {
+    return { status: 200, body: 'ok', headers: {} };
+  }
+
+  async destroySession(): Promise<void> {}
+}
+
+function makeSession(overrides: Partial<NotebookRpcSession> = {}): NotebookRpcSession {
+  return {
+    at: 'csrf-token-abc',
+    bl: 'boq_labs-tailwind-ui_20250101.00_p0',
+    fsid: '123456789',
+    cookies: 'SID=abc; HSID=def; SSID=ghi',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    ...overrides,
+  };
+}
+
+function makeRequest(overrides: Partial<TransportRequest> = {}): TransportRequest {
+  return {
+    url: 'https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute',
+    queryParams: {
+      rpcids: 'CCqFvf',
+      'source-path': '/',
+      bl: 'boq_labs-tailwind-ui_20250101.00_p0',
+      hl: 'en',
+      _reqid: '200000',
+      rt: 'c',
+    },
+    body: {
+      'f.req': '[[["CCqFvf","[\\"\\"]",null,"generic"]]]',
+      at: 'csrf-token-abc',
+    },
+    ...overrides,
+  };
+}
+
+function makeTransport(mock: MockTlsSessionClient): TlsClientTransport {
+  const transport = new TlsClientTransport({ session: makeSession() });
+  (transport as unknown as { sessionClient: MockTlsSessionClient }).sessionClient = mock;
+  return transport;
+}
+
+describe('TlsClientTransport', () => {
+  it('does not set per-request timeoutSeconds when req.timeoutMs is unset', async () => {
+    const mock = new MockTlsSessionClient();
+    const transport = makeTransport(mock);
+
+    await transport.execute(makeRequest());
+
+    expect(mock.posts).toHaveLength(1);
+    expect(mock.posts[0]?.opts?.timeoutSeconds).toBeUndefined();
+  });
+
+  it('passes req.timeoutMs as rounded-up timeoutSeconds', async () => {
+    const mock = new MockTlsSessionClient();
+    const transport = makeTransport(mock);
+
+    await transport.execute(makeRequest({ timeoutMs: 300_001 }));
+
+    expect(mock.posts).toHaveLength(1);
+    expect(mock.posts[0]?.opts?.timeoutSeconds).toBe(301);
+  });
+});


### PR DESCRIPTION
## Summary

Two of three transports (`curl-impersonate`, `tls-client`) hard-code a 60s timeout. `GenerateFreeFormStreamed` on large notebooks runs 120s+ — the underlying process gets killed mid-stream.

- Add `timeoutMs?: number` to `TransportRequest`
- `callChatStream` sets `300_000` (5min, 2.5x margin)
- All three transports forward it (curl `execFileAsync.timeout`, undici `bodyTimeout`/`headersTimeout`, tls-client `timeoutSeconds`)
- Other RPCs leave it unset, keep the 60s default — they finish in 1-5s

## Why

Web-UI Proxyman trace on a 31-PDF notebook: chat takes 120.4s server-side, 4MB streamed body. The 60s transport timeout truncates that. Easy to misdiagnose as "body too large" or "history accumulation" — neither is the cause (request body stays <100KB regardless of source count).

## Test plan

- [x] 5 new unit tests: client passes `300_000` for chat; transport-curl + transport-http forward `timeoutMs` (default + override)
- [x] 157 existing tests pass
- [x] End-to-end on 31-source notebook (curl-impersonate): chat returns in 87.9s, 1.2MB response
- [ ] tls-client transport: forwarding logic mirrors curl/http but not exercised live