### PR TITLE
fix(chat): fail loudly when sources empty or API returns empty text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -608,11 +608,30 @@ addBrowserOptions(chatCmd)
         ? (opts.sourceIds as string).split(',')
         : detail.sources.map((s) => s.id);
 
+      if (sourceIds.length === 0) {
+        console.error('[chat] ERROR: notebook has 0 sources visible to API.');
+        console.error('[chat] Likely cause: NotebookLM is still indexing recently uploaded files (eventual consistency, usually 2-10 min).');
+        console.error(`[chat] Fix: wait a few minutes and retry, or run \`notebooklm detail ${notebookId}\` to confirm sources are indexed before chatting.`);
+        process.exit(2);
+      }
+
       if (opts.withCitations) {
         const result = await client.sendChatWithCitations(notebookId, opts.question, sourceIds);
+        if (!result.text || result.text.trim() === '') {
+          console.error('[chat] ERROR: API returned empty text.');
+          console.error('[chat] Likely cause: stale session cookies or rate-limited account.');
+          console.error('[chat] Fix: re-run `notebooklm login` to refresh the session, then retry.');
+          process.exit(3);
+        }
         console.log(JSON.stringify(result, null, 2));
       } else {
         const result = await client.sendChat(notebookId, opts.question, sourceIds);
+        if (!result.text || result.text.trim() === '') {
+          console.error('[chat] ERROR: API returned empty text.');
+          console.error('[chat] Likely cause: stale session cookies or rate-limited account.');
+          console.error('[chat] Fix: re-run `notebooklm login` to refresh the session, then retry.');
+          process.exit(3);
+        }
         console.log(result.text);
       }
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { setHomeDir } from './paths.js';
 import type { SourceInput, WorkflowProgress } from './types.js';
 import { ARTIFACT_TYPE } from './rpc-ids.js';
 import { runSourceAdd, validateSourceAddOpts, type SourceAddOpts } from './commands/source-add.js';
+import { runChatCommand, type ChatCommandOptions } from './commands/chat.js';
 
 const program = new Command();
 
@@ -601,38 +602,17 @@ addBrowserOptions(chatCmd)
   .requiredOption('--question <q>', 'Question to ask')
   .option('--source-ids <ids>', 'Comma-separated source IDs (default: all)')
   .option('--with-citations', 'Include per-citation metadata in output')
-  .action(async (notebookId: string, opts) => {
+  .action(async (notebookId: string, opts: Parameters<typeof withClient>[0] & ChatCommandOptions) => {
     await withClient(opts, async (client) => {
-      const detail = await client.getNotebookDetail(notebookId);
-      const sourceIds = opts.sourceIds
-        ? (opts.sourceIds as string).split(',')
-        : detail.sources.map((s) => s.id);
-
-      if (sourceIds.length === 0) {
-        console.error('[chat] ERROR: notebook has 0 sources visible to API.');
-        console.error('[chat] Likely cause: NotebookLM is still indexing recently uploaded files (eventual consistency, usually 2-10 min).');
-        console.error(`[chat] Fix: wait a few minutes and retry, or run \`notebooklm detail ${notebookId}\` to confirm sources are indexed before chatting.`);
-        process.exit(2);
+      const result = await runChatCommand(client, notebookId, opts);
+      for (const line of result.stderr) {
+        console.error(line);
       }
-
-      if (opts.withCitations) {
-        const result = await client.sendChatWithCitations(notebookId, opts.question, sourceIds);
-        if (!result.text || result.text.trim() === '') {
-          console.error('[chat] ERROR: API returned empty text.');
-          console.error('[chat] Likely cause: stale session cookies or rate-limited account.');
-          console.error('[chat] Fix: re-run `notebooklm login` to refresh the session, then retry.');
-          process.exit(3);
-        }
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        const result = await client.sendChat(notebookId, opts.question, sourceIds);
-        if (!result.text || result.text.trim() === '') {
-          console.error('[chat] ERROR: API returned empty text.');
-          console.error('[chat] Likely cause: stale session cookies or rate-limited account.');
-          console.error('[chat] Fix: re-run `notebooklm login` to refresh the session, then retry.');
-          process.exit(3);
-        }
-        console.log(result.text);
+      if (result.stdout !== undefined) {
+        console.log(result.stdout);
+      }
+      if (result.exitCode !== 0) {
+        process.exitCode = result.exitCode;
       }
     });
   });

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -1,0 +1,87 @@
+import type { ChatWithCitationsResult, SourceInfo } from '../types.js';
+
+export interface ChatCommandClient {
+  getNotebookDetail(notebookId: string): Promise<{ sources: Pick<SourceInfo, 'id'>[] }>;
+  sendChat(notebookId: string, question: string, sourceIds: string[]): Promise<{ text: string; threadId: string }>;
+  sendChatWithCitations(notebookId: string, question: string, sourceIds: string[]): Promise<ChatWithCitationsResult>;
+}
+
+export interface ChatCommandOptions {
+  question: string;
+  sourceIds?: string;
+  withCitations?: boolean;
+}
+
+export interface ChatCommandResult {
+  exitCode: 0 | 2 | 3;
+  stdout?: string;
+  stderr: string[];
+}
+
+export function resolveChatSourceIds(rawSourceIds: string | undefined, detailSources: Pick<SourceInfo, 'id'>[]): string[] {
+  if (rawSourceIds === undefined) {
+    return detailSources.map((source) => source.id);
+  }
+
+  return rawSourceIds
+    .split(',')
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
+export async function runChatCommand(
+  client: ChatCommandClient,
+  notebookId: string,
+  opts: ChatCommandOptions,
+): Promise<ChatCommandResult> {
+  const detail = await client.getNotebookDetail(notebookId);
+  const sourceIds = resolveChatSourceIds(opts.sourceIds, detail.sources);
+
+  if (sourceIds.length === 0) {
+    return {
+      exitCode: 2,
+      stderr: [
+        '[chat] ERROR: notebook has 0 sources visible to API.',
+        '[chat] Likely cause: NotebookLM is still indexing recently uploaded files (eventual consistency, usually 2-10 min).',
+        `[chat] Fix: wait a few minutes and retry, or run \`notebooklm detail ${notebookId}\` to confirm sources are indexed before chatting.`,
+      ],
+    };
+  }
+
+  if (opts.withCitations) {
+    const result = await client.sendChatWithCitations(notebookId, opts.question, sourceIds);
+    if (isEmptyText(result.text)) {
+      return emptyTextResult();
+    }
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify(result, null, 2),
+      stderr: [],
+    };
+  }
+
+  const result = await client.sendChat(notebookId, opts.question, sourceIds);
+  if (isEmptyText(result.text)) {
+    return emptyTextResult();
+  }
+  return {
+    exitCode: 0,
+    stdout: result.text,
+    stderr: [],
+  };
+}
+
+function isEmptyText(text: string): boolean {
+  return text.trim() === '';
+}
+
+function emptyTextResult(): ChatCommandResult {
+  return {
+    exitCode: 3,
+    stderr: [
+      '[chat] ERROR: API returned empty text.',
+      '[chat] Likely cause: stale session cookies or rate-limited account.',
+      '[chat] Fix: re-run `npx notebooklm export-session` to refresh the session, then retry.',
+    ],
+  };
+}

--- a/tests/chat-command.test.ts
+++ b/tests/chat-command.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runChatCommand, type ChatCommandClient } from '../src/commands/chat.js';
+
+function makeClient(opts: {
+  sourceIds?: string[];
+  chatText?: string;
+  citationText?: string;
+} = {}) {
+  const sourceIds = opts.sourceIds ?? ['src-1'];
+  const chatText = opts.chatText ?? 'plain reply';
+  const citationText = opts.citationText ?? 'citation reply';
+
+  const client = {
+    getNotebookDetail: vi.fn(async (_notebookId: string) => ({
+      title: 'Notebook',
+      sources: sourceIds.map((id) => ({ id, title: `Source ${id}` })),
+    })),
+    sendChat: vi.fn(async (_notebookId: string, _question: string, _sourceIds: string[]) => ({
+      text: chatText,
+      threadId: 'thread-1',
+    })),
+    sendChatWithCitations: vi.fn(async (_notebookId: string, _question: string, _sourceIds: string[]) => ({
+      text: citationText,
+      threadId: 'thread-1',
+      responseId: 'response-1',
+      citations: [],
+    })),
+  } satisfies ChatCommandClient;
+
+  return client;
+}
+
+describe('runChatCommand', () => {
+  it('uses notebook detail sources when --source-ids is omitted', async () => {
+    const client = makeClient({ sourceIds: ['src-1', 'src-2'] });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: 'plain reply',
+      stderr: [],
+    });
+    expect(client.sendChat).toHaveBeenCalledWith('nb-1', 'Summarize this', ['src-1', 'src-2']);
+  });
+
+  it('treats explicit empty --source-ids as empty instead of falling back to all sources', async () => {
+    const client = makeClient({ sourceIds: ['src-1'] });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+      sourceIds: '',
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr.join('\n')).toMatch(/0 sources visible/);
+    expect(client.sendChat).not.toHaveBeenCalled();
+    expect(client.sendChatWithCitations).not.toHaveBeenCalled();
+  });
+
+  it('trims and drops blank entries from --source-ids', async () => {
+    const client = makeClient({ sourceIds: ['ignored'] });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+      sourceIds: ' src-1, ,src-2, ',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(client.sendChat).toHaveBeenCalledWith('nb-1', 'Summarize this', ['src-1', 'src-2']);
+  });
+
+  it('exits 2 when NotebookLM exposes no sources for the notebook', async () => {
+    const client = makeClient({ sourceIds: [] });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr.join('\n')).toMatch(/still indexing/);
+    expect(client.sendChat).not.toHaveBeenCalled();
+  });
+
+  it('exits 3 when the plain chat response text is empty', async () => {
+    const client = makeClient({ chatText: '  \n\t' });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+    });
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr.join('\n')).toMatch(/API returned empty text/);
+    expect(result.stderr.join('\n')).toContain('npx notebooklm export-session');
+  });
+
+  it('exits 3 when the citation chat response text is empty', async () => {
+    const client = makeClient({ citationText: '' });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+      withCitations: true,
+    });
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stdout).toBeUndefined();
+    expect(result.stderr.join('\n')).toMatch(/API returned empty text/);
+  });
+
+  it('prints citation results as formatted JSON when text is present', async () => {
+    const client = makeClient({ citationText: 'citation reply' });
+
+    const result = await runChatCommand(client, 'nb-1', {
+      question: 'Summarize this',
+      withCitations: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toEqual([]);
+    expect(result.stdout).toBe(JSON.stringify({
+      text: 'citation reply',
+      threadId: 'thread-1',
+      responseId: 'response-1',
+      citations: [],
+    }, null, 2));
+  });
+});

--- a/tests/e2e-chat-command.test.ts
+++ b/tests/e2e-chat-command.test.ts
@@ -1,0 +1,75 @@
+/**
+ * E2E tests for chat command guards.
+ *
+ * Requires a valid session (for example NOTEBOOKLM_HOME=~/.notebooklm-work)
+ * and a built CLI (`npm run build`). This test hits the real NotebookLM detail
+ * API and verifies the CLI fails before sending chat when the API exposes no sources.
+ */
+
+import { execFile, type ExecFileException } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const EMPTY_DETAIL_NOTEBOOK_ID = '00000000-0000-0000-0000-000000000000';
+
+function sessionPath(): string {
+  return join(process.env['NOTEBOOKLM_HOME'] ?? join(homedir(), '.notebooklm'), 'session.json');
+}
+
+function runNode(args: string[]): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      args,
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        maxBuffer: 1024 * 1024,
+        timeout: 60_000,
+      },
+      (error: ExecFileException | null, stdout: string, stderr: string) => {
+        if (!error) {
+          resolve({ exitCode: 0, stdout, stderr });
+          return;
+        }
+
+        if (typeof error.code === 'number') {
+          resolve({ exitCode: error.code, stdout, stderr });
+          return;
+        }
+
+        reject(error);
+      },
+    );
+  });
+}
+
+describe('E2E chat command guards', () => {
+  it('returns exit 2 when the real detail API exposes no sources', async () => {
+    if (!existsSync(sessionPath()) || !existsSync(join(process.cwd(), 'dist/cli.js'))) {
+      return expect(true).toBe(true);
+    }
+
+    const chatResult = await runNode([
+      'dist/cli.js',
+      'chat',
+      EMPTY_DETAIL_NOTEBOOK_ID,
+      '--question',
+      'This should not be sent',
+      '--transport',
+      'auto',
+    ]);
+
+    expect(chatResult.exitCode).toBe(2);
+    expect(chatResult.stdout).toBe('');
+    expect(chatResult.stderr).toMatch(/0 sources visible/);
+  }, 60_000);
+});


### PR DESCRIPTION
## Symptom

`notebooklm chat <id> --question "..."` silently exits 0 with no output in two situations, making it look like a successful call when the user actually got nothing back.

## Root cause

The chat action in `src/cli.ts` calls `getNotebookDetail` then passes `detail.sources.map(s => s.id)` straight into `sendChat` and prints `result.text` unconditionally. Two real-world cases this misses:

1. **Eventual consistency on freshly uploaded notebooks.** After uploading a source, NotebookLM's API surface can return `sources=[]` for 2-10 minutes while indexing completes. With an empty `sourceIds` array, `sendChat` returns an empty answer.
2. **Stale session / rate limit.** The backend can return `result.text === ""` even with valid sources.

Both currently `console.log("")` and exit 0. The CLI is unusable in scripts because you cannot tell success from silent failure.

## Fix

Two guards in the chat action:

- `sourceIds.length === 0` → `process.exit(2)` with an error pointing at the eventual-consistency cause and suggesting `notebooklm detail <id>` to verify sources before chatting.
- `result.text` empty/whitespace → `process.exit(3)` with an error suggesting a session refresh.

Applied to both the `--with-citations` and default branches.

## Regression test

Manual repro before the fix:

1. Create a notebook and upload a source.
2. Immediately (within ~30s) run `notebooklm chat <id> --question "test"`.
3. **Before:** exit 0, no output. **After:** exit 2, clear indexing message on stderr.

Alternatively, pass `--source-ids ""` to force an empty source list and hit the same guard deterministically.

## Notes

- Exit codes 2 and 3 chosen to leave 1 for generic command failures.
- Error messages go to stderr so stdout stays clean for the happy path (`console.log(result.text)` unchanged in shape).
- No new dependencies, no API surface change.